### PR TITLE
chor: make virustotal optional

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -295,6 +295,7 @@ jobs:
           path: build/package/deployment**
         if: always()
   security-virustotal:
+    continue-on-error: true
     name: security-virustotal
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make virustotal step optional since for larger files the step fails. Will require to implement a better github action for handling the large file scenario.