### PR TITLE
fix: remove tags update

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1380,13 +1380,3 @@ jobs:
           overwrite: true
           file_glob: true
           tag: v${{ steps.semantic.outputs.new_release_version }}
-
-  update-semver:
-    name: release-set-git-tags
-    if: always() && needs.publish.result == 'success' && startsWith(github.ref, 'refs/tags/v')
-    needs:
-      - publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: haya14busa/action-update-semver@v1


### PR DESCRIPTION
This is not needed for the add-on repositories and it is causing issues (like, https://github.com/splunk/addonfactory-ucc-generator/issues/404).