### PR TITLE
fix: adding splunk 9 support in tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -93,7 +93,7 @@ jobs:
             type=ref,event=pr
       - name: matrix
         id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1.7.0
+        uses: splunk/addonfactory-test-matrix-action@test/splunk-9.0
 
   compliance-sample-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -94,7 +94,7 @@ jobs:
             type=ref,event=pr
       - name: matrix
         id: matrix
-        uses: splunk/addonfactory-test-matrix-action@test/splunk-9.0
+        uses: splunk/addonfactory-test-matrix-action@v1.8
 
   compliance-sample-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -613,7 +613,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
+        splunk: [${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}]
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: [ ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }} ]
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -53,6 +53,7 @@ jobs:
       container_revision: ${{ fromJSON(steps.docker_action_meta.outputs.json).labels['org.opencontainers.image.revision'] }}
       container_base: ${{ fromJSON(steps.docker_action_meta.outputs.json).tags[0] }}
       matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
+      matrix_latestSplunk: ${{ steps.matrix.outputs.latestSplunk }}
       matrix_supportedSC4S: ${{ steps.matrix.outputs.supportedSC4S }}
       matrix_supportedModinputFunctionalVendors: ${{ steps.matrix.outputs.supportedModinputFunctionalVendors }}
       matrix_supportedUIVendors: ${{ steps.matrix.outputs.supportedUIVendors }}
@@ -774,7 +775,7 @@ jobs:
           reporter: java-junit
 
   run-requirement-tests:
-    if: ${{ needs.test-inventory.outputs.requirement_test == 'true' }} &&  ${{ matrix.splunk.islatest == true }}
+    if: ${{ needs.test-inventory.outputs.requirement_test == 'true' }}
     needs:
       - build
       - test-inventory
@@ -784,7 +785,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_latestSplunk) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1:] }}
+        splunk: [ "${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }}" ]
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ['8.2.1']
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: [ "${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }}" ]
+        splunk: [ "${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[1] }}" ]
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -774,7 +774,7 @@ jobs:
           reporter: java-junit
 
   run-requirement-tests:
-    if: ${{ needs.test-inventory.outputs.requirement_test == 'true' }}
+    if: ${{ needs.test-inventory.outputs.requirement_test == 'true' }} &&  ${{ matrix.splunk.islatest == true }}
     needs:
       - build
       - test-inventory
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: [ "${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[1] }}" ]
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3
@@ -828,7 +828,7 @@ jobs:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
         uses: splunk/wfe-test-runner-action@v1.6
         with:
-          splunk: ${{ matrix.splunk }}
+          splunk: ${{ matrix.splunk.version }}
           test-type: ${{ env.TEST_TYPE }}
           test-args: ""
           job-name: ${{ steps.create-job-name.outputs.job-name }}
@@ -912,20 +912,20 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: archive splunk ${{ matrix.splunk }} ${{ env.TEST_TYPE }} tests artifacts
+          name: archive splunk ${{ matrix.splunk.version }} ${{ env.TEST_TYPE }} tests artifacts
           path: |
             ${{ needs.setup.outputs.directory-path }}/test-results
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: archive splunk ${{ matrix.splunk }} ${{ env.TEST_TYPE }} tests logs
+          name: archive splunk ${{ matrix.splunk.version }} ${{ env.TEST_TYPE }} tests logs
           path: |
             ${{ needs.setup.outputs.directory-path }}/argo-logs
       - name: Test Report
         uses: dorny/test-reporter@v1
         if: always()
         with:
-          name: splunk ${{ matrix.splunk }} ${{ env.TEST_TYPE }} test report
+          name: splunk ${{ matrix.splunk.version }} ${{ env.TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
 

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -613,7 +613,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: [${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}]
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }}
+        splunk: [ ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }} ]
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -784,7 +784,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1] }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk)[-1:] }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3


### PR DESCRIPTION
Upgrade for:

- Splunk used for KO tests
- req tests now use newest Splunk version