### PR TITLE
fix: update virusTotal version to resolve large file scanning failure issue

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -321,7 +321,7 @@ jobs:
           path: build/package/
 
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@master
+        uses: crazy-max/ghaction-virustotal@3.0.0
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           files: |

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -321,7 +321,7 @@ jobs:
           path: build/package/
 
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@3.0.0
+        uses: crazy-max/ghaction-virustotal@3.1.0
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           files: |

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -321,7 +321,7 @@ jobs:
           path: build/package/
 
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@3.1.0
+        uses: crazy-max/ghaction-virustotal@v3.1.0
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           files: |

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -321,7 +321,7 @@ jobs:
           path: build/package/
 
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v3
+        uses: crazy-max/ghaction-virustotal@master
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           files: |


### PR DESCRIPTION
Update the virusTotal version from `@3` to `@master` to use the latest code that resolved the large file upload failure issue.