### PR TITLE
fix: don't create package/lib if no globalConfig.json file

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -219,7 +219,7 @@ jobs:
             sudo pip3 install poetry
             if [ -f "globalConfig.json" ]
             then
-              echo " globalConfig.json found, creating package/lib and installing exporting poetry dependencies "
+              echo " globalConfig.json found, creating package/lib and exporting poetry dependencies "
               mkdir -p package/lib || true
               poetry export --without-hashes -o package/lib/requirements.txt
             fi

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -215,10 +215,14 @@ jobs:
         run: |
           if [ -f "poetry.lock" ]
           then
-            echo " potery.lock found "
+            echo " poetry.lock found "
             sudo pip3 install poetry
-            mkdir -p package/lib || true
-            poetry export --without-hashes -o package/lib/requirements.txt
+            if [ -f "globalConfig.json" ]
+            then
+              echo " globalConfig.json found, creating package/lib and installing exporting poetry dependencies "
+              mkdir -p package/lib || true
+              poetry export --without-hashes -o package/lib/requirements.txt
+            fi
             poetry export --without-hashes --dev -o requirements_dev.txt
             cat requirements_dev.txt
           fi


### PR DESCRIPTION
There is no need to create package/lib folder and put empty
requirements.txt file there if we do not have globalConfig.json
file present in the repository, which is the indicator of
the add-on which needs Python dependencies to be installed under
package/lib folder.