### PR TITLE
feat: added firefox browser config for UI tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -762,7 +762,7 @@ jobs:
       fail-fast: false
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
-        browser: ["chrome"]
+        browser: ["chrome","firefox"]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3


### PR DESCRIPTION
Since firefox was removed to save credits in circleci, adding it back now to github actions to enhance the coverage as recently we found a bug in Firefox browser while executing GCP UI tests for Splunk Certification purpose.
Since this can introduce potential uncaught failures in addon, adding this as feat commit to give a choice/readiness time for dev teams to merge the minor version instead of a bugfix release that would directly add the firefox browser in all addons.