### PR TITLE
fix: remove PR title validation

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2048,20 +2048,6 @@ jobs:
           path: |
             ${{ needs.setup.outputs.directory-path }}/diag*
 
-  validate-pr-title:
-    name: Validate PR title
-    needs: 
-    - setup-workflow
-    if: ${{ needs.setup-workflow.outputs.skip-workflow != 'Yes' && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5.0.2
-        with:
-          wip: true
-          validateSingleCommit: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   pre-publish:
     if: always()
     needs:
@@ -2079,7 +2065,6 @@ jobs:
       - run-knowledge-tests
       - run-modinput-tests
       - run-ui-tests
-      - validate-pr-title
     runs-on: ubuntu-latest
     env:
       NEEDS: ${{ toJson(needs) }}


### PR DESCRIPTION
Everyone seems to be familiar with conventional commit approach now, so this check seems to be redundant.