### PR TITLE
fix: bump splunk/addonfactory-test-matrix-action to v1.9

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -191,7 +191,7 @@ jobs:
             type=ref,event=pr
       - name: matrix
         id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1.8
+        uses: splunk/addonfactory-test-matrix-action@v1.9
 
   fossa-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`splunk/addonfactory-test-matrix-action@v1.9` has a much smaller image (Python alpine versus plain Python) which will save a lot of time during the pipeline run.

This meta job for example took over 2 minutes to run https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/5092899462/jobs/9154853661?pr=449#step:2:53.

The v1.9 version https://github.com/splunk/addonfactory-ucc-generator/actions/runs/5090618123/jobs/9149662805#step:2:1 took 3 seconds.