### PR TITLE
fix: remove workflow_conclusion job

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -36,9 +36,6 @@ on:
       FOSSA_API_KEY:
         description: API token for FOSSA app
         required: true
-      SKYNET_TOKEN:
-        description: API token for Skynet
-        required: false
       SA_GH_USER_NAME:
         description: GPG signature username
         required: true

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1,4 +1,3 @@
-# jscpd:ignore-start
 name: build-test-release
 on:
   workflow_call:
@@ -2275,15 +2274,3 @@ jobs:
           overwrite: true
           file_glob: true
           tag: v${{ steps.semantic.outputs.new_release_version }}
-
-  get_workflow_conclusion:
-    if: always()
-    needs: [ publish ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send logs to Skynet
-        uses: splunk/collect-ta-logs@main
-        with:
-          git_token: ${{ github.token }}
-          skynet-token: ${{ secrets.SKYNET_TOKEN }}
-          skynet-url: "https://http-inputs-services-ingest.splunkcloud.com/services/collector/event"        


### PR DESCRIPTION
It does not work anyways and the contributor of this change is no longer working at Splunk. We can always restore it if we need in the future.

Tested change here: https://github.com/splunk/splunk-add-on-for-google-workspace/pull/457