### PR TITLE
chore: fix shellcheck sh2140 failures

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -105,8 +105,8 @@ jobs:
           set +e
           TESTSET="${{ steps.skip-workflow.outputs.testset }}"
           for test_type in $TESTSET; do
-              eval DELAY_DESTROY_"$test_type"="No"
-              eval EXECUTE_"$test_type"="Yes"
+              eval DELAY_DESTROY_$test_type="No"
+              eval EXECUTE_$test_type="Yes"
           done
           if [[ '${{ github.event.label.name }}' == 'preserve_infra' ]]; then
             echo "$PR_BODY" >> body.txt
@@ -116,9 +116,9 @@ jobs:
             fi
             for test_type in $TESTSET; do
                 if [[ $tests =~ $test_type ]]; then
-                    eval DELAY_DESTROY_"$test_type"="Yes"
+                    eval DELAY_DESTROY_$test_type="Yes"
                 else
-                    eval EXECUTE_"$test_type"="No" 
+                    eval EXECUTE_$test_type="No" 
                 fi
             done
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+actionlint


### PR DESCRIPTION
Tested here: https://github.com/splunk/splunk-add-on-for-google-workspace/pull/459