### PR TITLE
fix: rename step outputs

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -78,6 +78,8 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set +e
+          echo "github actor: "
+          echo ${{ github.actor }}
           TESTSET="knowledge ui modinput_functional scripted_inputs escu requirement_test"
           echo "testset=$TESTSET" >> "$GITHUB_OUTPUT"
           SKIP_WORKFLOW="No"


### PR DESCRIPTION
Previous fix which aimed on more detailed label name introduced issue with step output naming.
This PR fixes this issue.