### PR TITLE
chore: preserve infra - replace link with directions for LastPass

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -829,7 +829,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "For Splunk password please visit https://goo.by/splunk-password"
+          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: run-tests
         id: run-tests
         env:


### PR DESCRIPTION
Shortened goo link is no longer working.
Splunk password stored in Last Pass and instruction on accessing provided.