### PR TITLE
feat: run poetry lock --check during the build

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -525,6 +525,7 @@ jobs:
           then
             echo " poetry.lock found "
             sudo pip3 install poetry==1.2.2 poetry-plugin-export==1.2.0
+            poetry lock --check
             poetry export --without-hashes -o requirements.txt
             if [ "$(grep -cve '^\s*$' requirements.txt)" -ne 0 ]
             then

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+actionlint


### PR DESCRIPTION
Related [Jira](https://splunk.atlassian.net/browse/ADDON-63514).

This PR aims to remove the inconsistency with poetry usage for some of the repositories. We should block the build process if the `poetry.lock` file is not consistent with `pyproject.toml` file.

A run which fails when the `poetry.lock` is not consistent: https://github.com/splunk/splunk-add-on-for-cisco-meraki/actions/runs/6088301297/job/16518722640?pr=415#step:6:132
A run which does not fail when `poetry.lock` is consistent: https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/6088352198/job/16518888626
A run which ignores this check because there is no `poetry.lock`: https://github.com/splunk/splunk-add-on-for-mysql/actions/runs/6088361196/job/16518900173?pr=422