### PR TITLE
fix: py39 unit tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -639,11 +639,11 @@ jobs:
       - lint
       - review_secrets
       - semgrep
-      - run-unit-tests-311
+      - run-unit-tests-3_9
       - fossa-scan
     if: |
       always() &&
-      (needs.run-unit-tests-311.result == 'success' || needs.run-unit-tests-311.result == 'skipped')
+      (needs.run-unit-tests-3_9.result == 'success' || needs.run-unit-tests-3_9.result == 'skipped')
     permissions:
       contents: write
       packages: read

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -683,9 +683,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-python311-${{ hashFiles('requirements_dev.txt') }}
+          key: ${{ runner.os }}-pip-python3_9-${{ hashFiles('requirements_dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-python311
+            ${{ runner.os }}-pip-python3_9
       - run: pip install -r requirements_dev.txt
       - id: semantic
         if: github.event_name != 'pull_request'

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -443,7 +443,7 @@ jobs:
           name: test-results-unit-python_${{ matrix.python-version }}
           path: test-results/*
 
-  run-unit-tests-311:
+  run-unit-tests-3_9:
     name: test-unit-python3-${{ matrix.python-version }}
     if: ${{ needs.test-inventory.outputs.unit == 'true' }}
     runs-on: ubuntu-latest
@@ -453,7 +453,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.11"
+          - "3.9"
     permissions: 
       actions: read
       deployments: read
@@ -629,7 +629,7 @@ jobs:
           path: build/package/deployment**
         if: ${{ !cancelled() }}
 
-  build-311:
+  build-3_9:
     runs-on: ubuntu-latest
     needs:
       - setup-workflow
@@ -656,7 +656,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.9
       - name: create requirements file for pip
         run: |
           if [ -f "poetry.lock" ]


### PR DESCRIPTION
To follow up Python 3.7 EOL and 2.x Deprecation Program Page we need to be ready for python 3.9 with our apps.
As a first step let's monitor unit tests execution and build using python 3.9