### PR TITLE
chore: replace LastPass information with SecretServer

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1073,7 +1073,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: run-tests
         id: run-tests
         env:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1294,7 +1294,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: run-tests
         id: run-tests
         env:
@@ -1496,7 +1496,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: run-tests
         id: run-tests
         env:
@@ -1705,7 +1705,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: create test argument
         id: create-test-arg
         shell: bash
@@ -1923,7 +1923,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: get os name and version
         id: os-name-version
         shell: bash
@@ -2138,7 +2138,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: get os name and version
         id: os-name-version
         shell: bash
@@ -2351,7 +2351,7 @@ jobs:
           NORMAL="\033[0m"
           echo "Splunk Web UI will be available at https://${{ steps.create-job-name.outputs.job-name }}.${{ needs.setup.outputs.spl-host-suffix }}:8000 after test execution starts"
           echo -e "Splunk username is${BOLD} admin${NORMAL}"
-          echo "Splunk password is available in LastPass shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
+          echo "Splunk password is available in SecretServer shared folder: Shared Splunk - GDI - Lab Credentials under SPLUNK_DEPLOYMENT_PASSWORD"
       - name: get escu detections
         id: get-escu-detections
         run: |


### PR DESCRIPTION
As LastPass is being deprecated in Splunk, we need to update related information and direct to Secret Server.
More info:
https://docs.google.com/document/d/1sRYlWG22gpEJyltgchP0RQMeBqsFAjhlDQiTspp9zgA/edit