### PR TITLE
fix: splunk python 3.9 tests handling

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1175,6 +1175,8 @@ jobs:
       - name: pull logs from s3 bucket
         if: ${{ !cancelled() }}
         run: |
+          echo "matrix.splunk.version"
+          echo ${{ matrix.splunk.version }}
           # shellcheck disable=SC2157
           if [ -z "${{ steps.retry-wf.outputs.workflow-name }}" ]; then
             WORKFLOW_NAME=${{ steps.run-tests.outputs.workflow-name }}
@@ -1213,7 +1215,15 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased') }}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        id: test_report_python_3_9
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -265,8 +265,8 @@ jobs:
             type=ref,event=pr
       - name: matrix
         id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1.10
-
+        uses: splunk/addonfactory-test-matrix-action@feat/add-unreleased-splunk
+        
   fossa-scan:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -265,8 +265,8 @@ jobs:
             type=ref,event=pr
       - name: matrix
         id: matrix
-        uses: splunk/addonfactory-test-matrix-action@feat/add-unreleased-splunk
-        
+        uses: splunk/addonfactory-test-matrix-action@v1.11
+
   fossa-scan:
     runs-on: ubuntu-latest
     needs:
@@ -1175,8 +1175,6 @@ jobs:
       - name: pull logs from s3 bucket
         if: ${{ !cancelled() }}
         run: |
-          echo "matrix.splunk.version"
-          echo ${{ matrix.splunk.version }}
           # shellcheck disable=SC2157
           if [ -z "${{ steps.retry-wf.outputs.workflow-name }}" ]; then
             WORKFLOW_NAME=${{ steps.run-tests.outputs.workflow-name }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1215,7 +1215,7 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased') }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -1224,7 +1224,7 @@ jobs:
         continue-on-error: true
         id: test_report_python_3_9
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased') }}
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -1426,7 +1426,16 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9') }}
+        with:
+          name: splunk ${{ matrix.splunk.version }} ${{ env.TEST_TYPE }} test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        continue-on-error: true
+        id: test_report_python_3_9
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }} ${{ env.TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -1635,7 +1644,16 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9') }}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        id: test_report_python_3_9
+        continue-on-error: true
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -1857,7 +1875,15 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9') }}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        id: test_report_python_3_9
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -2073,7 +2099,15 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9') }}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }}  test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        id: test_report_python_3_9
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }}  test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -2288,7 +2322,15 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9') }}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }}  test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        id: test_report_python_3_9
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9') }}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }}  test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
@@ -2513,7 +2555,15 @@ jobs:
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1
-        if: ${{ steps.get-escu-detections.outputs.escu-test-run == 'true' }}
+        if: ${{ steps.get-escu-detections.outputs.escu-test-run == 'true' && !cancelled() && !contains(matrix.splunk.version, 'unreleased-python3_9')}}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Test Report Python 3.9
+        id: test_report_python_3_9
+        uses: dorny/test-reporter@v1
+        if: ${{ steps.get-escu-detections.outputs.escu-test-run == 'true' && !cancelled() && contains(matrix.splunk.version, 'unreleased-python3_9')}}
         with:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1221,6 +1221,7 @@ jobs:
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
       - name: Test Report Python 3.9
+        continue-on-error: true
         id: test_report_python_3_9
         uses: dorny/test-reporter@v1
         if: ${{ !cancelled() && contains(matrix.splunk.version, 'unreleased') }}


### PR DESCRIPTION
- bump addonfactory-test-matrix-action to v1.11 which includes unreleased splunk image with python 3.9 
- add to all tests step `Test Report Python 3.9` with `continue-on-error` option to run tests on python 3.9 and not fail workflows
- step `Test Report` is executed for all official splunk images, `Test Report Python 3.9` is executed only for not released splunk images with tag ~unreleased-python3_9

This approach enables the execution of tests on a Splunk image with Python 3.9 without causing the entire workflows to fail. However, the downside is that tests performed on Splunk with Python 3.9 consistently result with success. Therefore, it is necessary to manually verify the test outcomes to ensure the proper functioning of TA tests with Python 3.9.

Tests:
1. Tests failing, `pre-publish` job failed because of tests failed on released splunk
 https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/6466779160/job/17556629002
2. Tests failing, `pre-publish` job passed because tests were executed only on unreleased splunk
https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/6466779160/attempts/1