### PR TITLE
fix: rename semgrep action

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -361,7 +361,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Semgrep
         id: semgrep
-        uses: returntocorp/semgrep-action@v1
+        uses: semgrep/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 


### PR DESCRIPTION
This commit renames semgrep action used due to a change upstream.

Testing here: https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1098