### PR TITLE
fix: align concurrency groups

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -55,7 +55,7 @@ permissions:
   contents: read
   packages: read
 concurrency: 
-  group: ${{ github.head_ref || github.ref_name }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   setup-workflow:


### PR DESCRIPTION
Fixing a issue when workflow `github.ref_name` was causing undesired cancellation of other running workflows.
This condition is too broad.