### PR TITLE
fix: run appinspect-api only on all tags by default

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -819,7 +819,7 @@ jobs:
       fail-fast: false
       matrix:
         tags:
-          - ""
+          - "cloud"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -819,8 +819,6 @@ jobs:
       fail-fast: false
       matrix:
         tags:
-          - "cloud"
-          - "self-service"
           - ""
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Rationale:
There is no point in running appinspect api for particular tags if we run for all.
https://splunk.slack.com/archives/CBFTW8QRG/p1700059679560229