### PR TITLE
feat: update splunk/addonfactory-test-matrix-action to v1.13

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -267,7 +267,7 @@ jobs:
             type=ref,event=pr
       - name: matrix
         id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1.10
+        uses: splunk/addonfactory-test-matrix-action@v1.13
       - name: python39_Splunk
         id: python39_splunk
         run: |


### PR DESCRIPTION
This PR updates splunk/addonfactory-test-matrix-action to v1.13 which includes Splunk version updates:

* 9.1.1 -> 9.1.2
* 9.0.6 -> 9.0.7