### PR TITLE
feat: update appinspect-cli to 2.0 and other dependencies

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: apache/skywalking-eyes@v0.4.0
+      - uses: apache/skywalking-eyes@v0.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.7"
       - run: |

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -211,7 +211,7 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         with:
           wip: true
           validateSingleCommit: true
@@ -260,7 +260,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Docker meta
         id: docker_action_meta
-        uses: docker/metadata-action@v4.6.0
+        uses: docker/metadata-action@v5.4.0
         with:
           images: ghcr.io/${{ github.repository }}/container
           tags: |
@@ -334,7 +334,7 @@ jobs:
     if: ${{ needs.setup-workflow.outputs.skip-workflow != 'Yes' }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.7"
       - uses: pre-commit/action@v3.0.0
@@ -428,7 +428,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup addon
@@ -476,7 +476,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup addon
@@ -529,7 +529,7 @@ jobs:
           # build if this is not set false
           persist-credentials: false
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
       - name: create requirements file for pip
@@ -667,7 +667,7 @@ jobs:
           # build if this is not set false
           persist-credentials: false
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: create requirements file for pip
@@ -733,7 +733,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v3
+        uses: crazy-max/ghaction-virustotal@v4
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           files: |
@@ -755,7 +755,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
       - name: run-tests
@@ -794,7 +794,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v1.12
+        uses: splunk/appinspect-cli-action@v2.0
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}
@@ -874,7 +874,7 @@ jobs:
           mv oras-install/oras /usr/local/bin/
           rm -rf oras_0.12.0_*.tar.gz oras-install/
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v2.2.0
         with:
@@ -883,7 +883,7 @@ jobs:
           password: ${{ github.token }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4.6.0
+        uses: docker/metadata-action@v5.4.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -993,7 +993,7 @@ jobs:
           path: ${{ github.workspace }}
       - name: Setup python
         if: steps.download-openapi.conclusion != 'skipped'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
       - name: modinput-test-prerequisites


### PR DESCRIPTION
This updates every dependency that is not being run on container `ghcr.io/splunk/workflow-engine-base` as it does not support node20 in current version.

Updated depenencies:

- apache/skywalking-eyes@v0.5.0
- actions/setup-python@v5
- amannn/action-semantic-pull-request@v5.4.0
- docker/metadata-action@v5.4.0
- crazy-max/ghaction-virustotal@v4
- splunk/appinspect-cli-action@v2.0
- docker/setup-buildx-action@v3

Tested here: https://github.com/splunk/splunk-add-on-for-cisco-meraki/actions/runs/7396274137