### PR TITLE
feat: pre-publish job adjusted to triggering event

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2671,7 +2671,7 @@ jobs:
 
   pre-publish:
     if: ${{ !cancelled() }}
-    # The following line will rename 'pre-bublish' to 'pre-publish-not_main_pr' when PR is created towards main branch
+    # The following line will rename 'pre-publish' to 'pre-publish-not_main_pr' when PR is created towards main branch
     # It is necessary to avoid confusion caused by githubactions considering pre-publish for both push to develop branch
     # and pull_request to main branch events.
     name: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' &&  'pre-publish' ||  'pre-publish-not_main_pr' }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2671,6 +2671,10 @@ jobs:
 
   pre-publish:
     if: ${{ !cancelled() }}
+    # The following line will rename 'pre-bublish' to 'pre-publish-not_main_pr' when PR is created towards main branch
+    # It is necessary to avoid confusion caused by githubactions considering pre-publish for both push to develop branch
+    # and pull_request to main branch events.
+    name: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' &&  'pre-publish' ||  'pre-publish-not_main_pr' }}
     needs:
       - meta
       - compliance-copyrights


### PR DESCRIPTION
This PR regards https://splunk.atlassian.net/browse/ADDON-67617
It introduces dynamic change of pre-publish job which was necessary to avoid confusion while creating PR towards main branch having had pushed to develop branch. 

tests: 
- pr: https://github.com/splunk/splunk-add-on-for-mysql/pull/464
- push to develop workflow (name has been changed): https://github.com/splunk/splunk-add-on-for-mysql/actions/runs/7399079510
- pr to main workflow (name remains intact): https://github.com/splunk/splunk-add-on-for-mysql/actions/runs/7399125452
