### PR TITLE
refactor: semgrep job update

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -376,8 +376,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Semgrep
         id: semgrep
-        run: |
-          semgrep ci
+        run: semgrep ci
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -377,10 +377,9 @@ jobs:
       - name: Semgrep
         id: semgrep
         run: |
-          semgrep login && \
           semgrep ci
         env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 
   test-inventory:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -376,7 +376,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Semgrep
         id: semgrep
-        run: semgrep ci
+        run: |
+          semgrep login --token $SEMGREP_APP_TOKEN && \
+          semgrep ci
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Semgrep
         id: semgrep
         run: |
-          semgrep login --token $SEMGREP_APP_TOKEN && \
+          semgrep login && \
           semgrep ci
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -369,14 +369,16 @@ jobs:
     name: security-sast-semgrep
     needs:
       - setup-workflow
-    if: ${{ needs.setup-workflow.outputs.skip-workflow != 'Yes' && github.actor != 'dependabot[bot]' }}
+    container:
+      image: returntocorp/semgrep
+    if: ${{ needs.setup-workflow.outputs.skip-workflow != 'Yes' }}
     steps:
       - uses: actions/checkout@v3
       - name: Semgrep
         id: semgrep
-        uses: semgrep/semgrep-action@v1
-        with:
-          publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
+        run: semgrep ci
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
   test-inventory:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ security-sast-semgrep
 **Description:**
 
 - Semgrep CI behaves like other static analysis and linting tools: it runs a set of user-configured rules and returns a non-zero exit code if there are findings, resulting in its job showing a ✅ or ❌.
-
-**Action used:** https://github.com/returntocorp/semgrep-action
-
+- Semgrep can do two scan types: 
+  - diff-aware scan, performed while workflow triggering event is pull request and scans only changes in files, which keeps the scan fast and reduces finding duplication.
+  - full scan, performed while workflow triggering event is other event (e.g. push) and scans the whole codebase.
 
 **Pass/fail behaviour**
 


### PR DESCRIPTION
This PR update semgrep job in the reusable-build-test-release.ym. 
The change was necessary, because previously used semgrep-action was deprecated.

Jira: https://splunk.atlassian.net/browse/ADDON-67642

Tested on: https://github.com/splunk/test-addonfactory-repo/actions/runs/7421872771/job/20196096465