### PR TITLE
chore: github dependencies support for ssh

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -440,7 +440,8 @@ jobs:
              poetry export --without-hashes --dev -o requirements_dev.txt
            fi
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
-          git config --global url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           pip install -r requirements_dev.txt
       - name: Create directories
         run: |
@@ -489,7 +490,8 @@ jobs:
              poetry export --without-hashes --dev -o requirements_dev.txt
            fi
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
-          git config --global url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           pip install -r requirements_dev.txt
       - name: Create directories
         run: |
@@ -571,7 +573,8 @@ jobs:
       - name: Install deps
         if: ${{ steps.checklibs.outputs.ENABLED == 'true' }}
         run: |
-          git config --global url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           pip install -r requirements_dev.txt
       - name: Semantic Release Get Next
         id: semantic
@@ -703,7 +706,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-python3_9
       - run: |
-          git config --global url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           pip install -r requirements_dev.txt
       - id: semantic
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
We are generally using ssh key for development instead of https.

this will support both cases in requirements.txt and poetry

Poetry example:
```
splunksdc = {git = "https://github.com/splunk/splunksdc.git", tag = "v0.1.2"}

splunksdc = {git = "ssh://git@github.com/splunk/splunksdc.git", tag = "v0.1.2"}
``` 