### PR TITLE
chore: update appinspect-cli to 2.2

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -781,7 +781,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.0
+        uses: splunk/appinspect-cli-action@v2.2
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
tested here: https://github.com/splunk/splunk-add-on-for-crowdstrike-fdr/actions/runs/7612474417/job/20730350677?pr=823