### PR TITLE
feat: remove firefox from ui tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1486,7 +1486,7 @@ jobs:
       fail-fast: false
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
-        browser: [ "chrome","firefox" ]
+        browser: [ "chrome" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
         python39: [false]
         include:


### PR DESCRIPTION
This PR removes firefox from ui tests execution, since firefox is ranked 4th in Desktop Browser Market Share Worldwide.
https://splunk.atlassian.net/browse/ADDON-68235
tested here: https://github.com/splunk/test-addonfactory-repo/actions/runs/7815971598/job/21320701943