### PR TITLE
feat(release): addonfactory packaging toolkit action removal

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -652,7 +652,7 @@ jobs:
           mkdir -p build/package/splunkbase
           slim package -o build/package/splunkbase "${INPUT_SOURCE}" 
           for f in build/package/splunkbase/*.tar.gz; do
-            n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
+            n=$(echo "${f}" | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
             mv "${f}" "${n}"
           done
           PACKAGE=$(ls build/package/splunkbase/*)

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -679,6 +679,12 @@ jobs:
           echo "name=$(basename "${{ steps.slim.outputs.OUTPUT }}")" >> "$GITHUB_OUTPUT"
           basename "${{ steps.slim.outputs.OUTPUT }}"
           aws s3 cp "${{ steps.slim.outputs.OUTPUT }}" s3://ta-production-artifacts/ta-apps/
+      - name: artifact-splunk-parts
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-deployment
+          path: build/package/deployment**
+        if: ${{ !cancelled() }}
 
   build-3_9:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -679,12 +679,6 @@ jobs:
           echo "name=$(basename "${{ steps.slim.outputs.OUTPUT }}")" >> "$GITHUB_OUTPUT"
           basename "${{ steps.slim.outputs.OUTPUT }}"
           aws s3 cp "${{ steps.slim.outputs.OUTPUT }}" s3://ta-production-artifacts/ta-apps/
-      - name: artifact-splunk-parts
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-deployment
-          path: build/package/deployment**
-        if: ${{ !cancelled() }}
 
   build-3_9:
     runs-on: ubuntu-latest
@@ -2715,13 +2709,6 @@ jobs:
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}
-      - name: Download package-deployment
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
-        uses: actions/download-artifact@v3
-        id: download-package-deployment
-        with:
-          name: package-deployment
-          path: download/artifacts/
       - name: Download package-splunkbase
         if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -639,16 +639,13 @@ jobs:
       - name: Slim Package
         id: slim
         run: |
-          pip install semantic_version==2.6.0
-          pip install https://download.splunk.com/misc/packaging-toolkit/splunk-packaging-toolkit-1.0.1.tar.gz
+          pip install splunk-packaging-toolkit
           INPUT_SOURCE=${{ steps.uccgen.outputs.OUTPUT }}
           SOURCE_REGEX='^.*/$'
           if [[ $INPUT_SOURCE =~ $SOURCE_REGEX ]];then
             echo Removing trailing / from INPUT_SOURCE slim is picky
             INPUT_SOURCE=$(echo $INPUT_SOURCE | sed 's/\(.*\)\//\1/')
           fi
-          slim generate-manifest "${INPUT_SOURCE}" --update >/tmp/app.manifest   || true
-          cp  /tmp/app.manifest  "${INPUT_SOURCE}/app.manifest"
           mkdir -p build/package/splunkbase
           slim package -o build/package/splunkbase "${INPUT_SOURCE}" 
           for f in build/package/splunkbase/*.tar.gz; do

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -650,18 +650,12 @@ jobs:
           slim generate-manifest $INPUT_SOURCE --update >/tmp/app.manifest   || true
           cp  /tmp/app.manifest  $INPUT_SOURCE/app.manifest
           mkdir -p build/package/splunkbase
-          mkdir -p build/package/deployment
           slim package -o build/package/splunkbase $INPUT_SOURCE 
           for f in build/package/splunkbase/*.tar.gz; do
             n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
             mv $f $n
           done
           PACKAGE=$(ls build/package/splunkbase/*)
-          slim partition $PACKAGE -o build/package/deployment/ || true
-          for f in build/package/deployment/*.tar.gz; do
-            n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
-            mv $f $n
-          done
           slim validate $PACKAGE
           chmod -R +r build
           echo "OUTPUT=$PACKAGE" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -638,9 +638,36 @@ jobs:
           version: ${{ steps.BuildVersion.outputs.VERSION }}
       - name: Slim Package
         id: slim
-        uses: splunk/addonfactory-packaging-toolkit-action@v1
-        with:
-          source: ${{ steps.uccgen.outputs.OUTPUT }}
+        run: |
+          pip install semantic_version==2.6.0
+          pip install https://download.splunk.com/misc/packaging-toolkit/splunk-packaging-toolkit-1.0.1.tar.gz
+          INPUT_SOURCE=${{ steps.uccgen.outputs.OUTPUT }}
+          SOURCE_REGEX='^.*/$'
+          if [[ $INPUT_SOURCE =~ $SOURCE_REGEX ]];then
+            echo Removing trailing / from INPUT_SOURCE slim is picky
+            INPUT_SOURCE=$(echo $INPUT_SOURCE | sed 's/\(.*\)\//\1/')
+          fi
+          slim generate-manifest $INPUT_SOURCE --update >/tmp/app.manifest   || true
+          cp  /tmp/app.manifest  $INPUT_SOURCE/app.manifest
+          mkdir -p build/package/splunkbase
+          slim package -o build/package/splunkbase $INPUT_SOURCE 
+          for f in build/package/splunkbase/*.tar.gz; do
+            n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
+            mv $f $n
+          done
+          PACKAGE=$(ls build/package/splunkbase/*)
+          #By default, the Packaging Toolkit partitions an app into deployment packages targeting all workloads.
+          if [[ $(jq -e '.targetWorkloads != null' $INPUT_SOURCE/app.manifest | tr -d '\n') == true ]];then
+            mkdir -p build/package/deployment
+            slim partition $PACKAGE -o build/package/deployment/ || true
+            for f in build/package/deployment/*.tar.gz; do
+              n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
+              mv $f $n
+            done
+          fi
+          slim validate $PACKAGE
+          chmod -R +r build
+          echo "OUTPUT=$PACKAGE" >> $GITHUB_OUTPUT
         if: always()
       - name: artifact-openapi
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -647,18 +647,18 @@ jobs:
             echo Removing trailing / from INPUT_SOURCE slim is picky
             INPUT_SOURCE=$(echo $INPUT_SOURCE | sed 's/\(.*\)\//\1/')
           fi
-          slim generate-manifest $INPUT_SOURCE --update >/tmp/app.manifest   || true
-          cp  /tmp/app.manifest  $INPUT_SOURCE/app.manifest
+          slim generate-manifest "${INPUT_SOURCE}" --update >/tmp/app.manifest   || true
+          cp  /tmp/app.manifest  "${INPUT_SOURCE}/app.manifest"
           mkdir -p build/package/splunkbase
-          slim package -o build/package/splunkbase $INPUT_SOURCE 
+          slim package -o build/package/splunkbase "${INPUT_SOURCE}" 
           for f in build/package/splunkbase/*.tar.gz; do
             n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
-            mv $f $n
+            mv "${f}" "${n}"
           done
           PACKAGE=$(ls build/package/splunkbase/*)
-          slim validate $PACKAGE
+          slim validate "${PACKAGE}"
           chmod -R +r build
-          echo "OUTPUT=$PACKAGE" >> $GITHUB_OUTPUT
+          echo "OUTPUT=$PACKAGE" >> "$GITHUB_OUTPUT"
         if: always()
       - name: artifact-openapi
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -682,12 +682,6 @@ jobs:
           echo "name=$(basename "${{ steps.slim.outputs.OUTPUT }}")" >> "$GITHUB_OUTPUT"
           basename "${{ steps.slim.outputs.OUTPUT }}"
           aws s3 cp "${{ steps.slim.outputs.OUTPUT }}" s3://ta-production-artifacts/ta-apps/
-      - name: artifact-splunk-parts
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-deployment
-          path: build/package/deployment**
-        if: ${{ !cancelled() }}
 
   build-3_9:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -650,21 +650,18 @@ jobs:
           slim generate-manifest $INPUT_SOURCE --update >/tmp/app.manifest   || true
           cp  /tmp/app.manifest  $INPUT_SOURCE/app.manifest
           mkdir -p build/package/splunkbase
+          mkdir -p build/package/deployment
           slim package -o build/package/splunkbase $INPUT_SOURCE 
           for f in build/package/splunkbase/*.tar.gz; do
             n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
             mv $f $n
           done
           PACKAGE=$(ls build/package/splunkbase/*)
-          #By default, the Packaging Toolkit partitions an app into deployment packages targeting all workloads.
-          if [[ $(jq -e '.targetWorkloads != null' $INPUT_SOURCE/app.manifest | tr -d '\n') == true ]];then
-            mkdir -p build/package/deployment
-            slim partition $PACKAGE -o build/package/deployment/ || true
-            for f in build/package/deployment/*.tar.gz; do
-              n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
-              mv $f $n
-            done
-          fi
+          slim partition $PACKAGE -o build/package/deployment/ || true
+          for f in build/package/deployment/*.tar.gz; do
+            n=$(echo $f | awk '{gsub("-[0-9]+.[0-9]+.[0-9]+-[a-f0-9]+-?", "");print}' | sed 's/.tar.gz/.spl/')
+            mv $f $n
+          done
           slim validate $PACKAGE
           chmod -R +r build
           echo "OUTPUT=$PACKAGE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR removes addonfactory-packaging-toolkit-action from the workflow and replaces it with direct logic. It also skips the step of partitioning so release on GitHub only contains files that are used by the developers.
https://splunk.atlassian.net/browse/ADDON-68239
Tested here: https://github.com/splunk/test-addonfactory-repo/actions/runs/7902209078

Example release : https://github.com/splunk/test-addonfactory-repo/releases/tag/v0.7.2