### PR TITLE
chore: update wfe-base and set up git safe directory

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1068,7 +1068,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time
@@ -1316,7 +1316,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time
@@ -1545,7 +1545,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time
@@ -1781,7 +1781,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time
@@ -2026,7 +2026,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time
@@ -2262,7 +2262,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time
@@ -2505,7 +2505,7 @@ jobs:
         id: configure-git
         run: |
           git --version
-          git_path=$(pwd)
+          git_path="$(pwd)"
           echo $git_path
           git config --global --add safe.directory "$git_path"
       - name: capture start time

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1069,7 +1069,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
@@ -1317,7 +1317,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
@@ -1546,7 +1546,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
@@ -1782,7 +1782,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
@@ -2027,7 +2027,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
@@ -2263,7 +2263,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
@@ -2506,7 +2506,7 @@ jobs:
         run: |
           git --version
           git_path="$(pwd)"
-          echo $git_path
+          echo "$git_path"
           git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1064,7 +1064,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version
@@ -1312,7 +1312,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version
@@ -1541,7 +1541,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version
@@ -1777,7 +1777,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version
@@ -2022,7 +2022,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version
@@ -2258,7 +2258,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version
@@ -2501,7 +2501,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: configure git
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
         id: configure-git
         run: |
           git --version

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1043,7 +1043,7 @@ jobs:
               sc4s: ${{ fromJson(needs.meta.outputs.python39_sc4s) }}
               python39: true
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1064,6 +1064,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |
@@ -1285,7 +1292,7 @@ jobs:
               sc4s: ${{ fromJson(needs.meta.outputs.python39_sc4s) }}
               python39: true
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1305,6 +1312,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |
@@ -1506,7 +1520,7 @@ jobs:
               browser: "chrome"
               python39: true
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1527,6 +1541,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |
@@ -1735,7 +1756,7 @@ jobs:
               modinput-type: [ "modinput_functional" ]
               python39: true
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1756,6 +1777,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |
@@ -1974,7 +2002,7 @@ jobs:
               os: "ubuntu:22.04"
               python39: true
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1994,6 +2022,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |
@@ -2203,7 +2238,7 @@ jobs:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
         os: [ "ubuntu:22.04", "centos:7","redhat:8.5" ]
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -2223,6 +2258,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |
@@ -2439,7 +2481,7 @@ jobs:
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_latestSplunk) }}
     container:
-      image: ghcr.io/splunk/workflow-engine-base:2.0.3
+      image: ghcr.io/splunk/workflow-engine-base:2.0.12
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -2459,6 +2501,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: configure git
+        id: configure-git
+        run: |
+          git --version
+          git_path=$(pwd)
+          echo $git_path
+          git config --global --add safe.directory "$git_path"
       - name: capture start time
         id: capture-start-time
         run: |


### PR DESCRIPTION
Image 2.0.12 uses git 2.39 and 2.0.3 uses 2.32. This error was intoduced with git 2.36. It requires setting up safe directory (probably here is some other way to fix it, but this works)

Tested here: 
- https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/8005834200
- https://github.com/splunk/splunk-add-on-for-cisco-meraki/actions/runs/8005821163