### PR TITLE
fix: update AppInspect CLI action to v2.3

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -785,7 +785,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.2
+        uses: splunk/appinspect-cli-action@v2.3
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
Release: https://github.com/splunk/appinspect-cli-action/releases/tag/v2.3.0
Release notes: https://dev.splunk.com/enterprise/docs/relnotes/relnotes-appinspectcli/whatsnew/#v3302024-03-04

Test PR: https://github.com/splunk/splunk-add-on-for-google-workspace/pull/537