### PR TITLE
fix: update AppInspect CLI action to v2.4

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -785,7 +785,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.3
+        uses: splunk/appinspect-cli-action@v2.4
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
Release:
https://github.com/splunk/appinspect-cli-action/releases/tag/v2.4.0 Release notes:
https://dev.splunk.com/enterprise/docs/relnotes/relnotes-appinspectcli/whatsnew/#v3402024-03-14

Test PR: 
https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/8297872866