### PR TITLE
fix: combining splunk versions

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1723,7 +1723,6 @@ jobs:
         modinput-type: [ "modinput_functional" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         marker: ${{ fromJson(inputs.marker) }}
-        python39: [false]
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3
     env:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -230,6 +230,7 @@ jobs:
       container_base: ${{ fromJSON(steps.docker_action_meta.outputs.json).tags[0] }}
       matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
       matrix_latestSplunk: ${{ steps.matrix.outputs.latestSplunk }}
+      matrix_combinedSplunkversion: ${{ steps.combined_Splunkmatrix.outputs.combinedSplunkversions }}
       matrix_supportedSC4S: ${{ steps.matrix.outputs.supportedSC4S }}
       matrix_supportedModinputFunctionalVendors: ${{ steps.matrix.outputs.supportedModinputFunctionalVendors }}
       matrix_supportedUIVendors: ${{ steps.matrix.outputs.supportedUIVendors }}
@@ -276,6 +277,12 @@ jobs:
         run: |
           echo "splunk={\"version\":\"unreleased-python3_9-7027496d63d8\", \"build\":\"7027496d63d8\", \"islatest\":false, \"isoldest\":false}" >> "$GITHUB_OUTPUT"
           echo "sc4s={\"version\":\"2.49.5\", \"docker_registry\":\"ghcr.io/splunk/splunk-connect-for-syslog/container2\"}"  >> "$GITHUB_OUTPUT"
+      - name: combined_Splunkmatrix
+        id: combined_Splunkmatrix
+        run: |
+            combinedSplunkversions=$(echo '${{ steps.matrix.outputs.supportedSplunk }}'  | jq --argjson A '${{steps.python39_splunk.outputs.splunk}}' '. + [$A]')
+            echo "combinedSplunkversions=$(echo "$combinedSplunkversions"| jq -c .)" >> "$GITHUB_OUTPUT"
+
 
   fossa-scan:
     runs-on: ubuntu-latest
@@ -1709,19 +1716,14 @@ jobs:
       - meta
       - setup-workflow
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.python39 }}
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_combinedSplunkversion) }}
         modinput-type: [ "modinput_functional" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         marker: ${{ fromJson(inputs.marker) }}
         python39: [false]
-        include:
-            - splunk: ${{ fromJson(needs.meta.outputs.python39_splunk) }}
-              modinput-type: [ "modinput_functional" ]
-              python39: true
     container:
       image: ghcr.io/splunk/workflow-engine-base:2.0.3
     env:


### PR DESCRIPTION
Added stage to combine splunk versions an use it in modinput test job.

Job in AWS addon where modinut is running successfully with python3.9 (Matrix of 24 jobs 3*8): https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/8431526533

Job in MSCS addon : https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/8431532363