### PR TITLE
fix: update AppInspect CLI action to v2.5

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -792,7 +792,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.4
+        uses: splunk/appinspect-cli-action@v2.5
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
Release version 2.5 for reusable build test release.
[https://github.com/splunk/appinspect-cli-action/releases/tag/v2.5.0](url)
[https://dev.splunk.com/enterprise/docs/relnotes/relnotes-appinspectcli/whatsnew/#v3502024-03-27](url)
[https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/8464669953](url)
