### PR TITLE
fix: change deps installation method in unit tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -463,7 +463,7 @@ jobs:
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          pip install -r requirements_dev.txt
+          poetry install --with=dev
       - name: Create directories
         run: |
           mkdir -p /opt/splunk/var/log/splunk
@@ -514,7 +514,7 @@ jobs:
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          pip install -r requirements_dev.txt
+          poetry install --with=dev
       - name: Create directories
         run: |
           mkdir -p /opt/splunk/var/log/splunk

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -463,7 +463,6 @@ jobs:
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry config virtualenvs.create false
           poetry install --with dev
       - name: Create directories
         run: |
@@ -472,7 +471,7 @@ jobs:
       - name: Copy pytest ini
         run: cp tests/unit/pytest-ci.ini pytest.ini
       - name: Run Pytest with coverage
-        run: pytest --cov=./ --cov-report=xml --junitxml=test-results/junit.xml tests/unit
+        run: poetry run pytest --cov=./ --cov-report=xml --junitxml=test-results/junit.xml tests/unit
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
@@ -515,7 +514,6 @@ jobs:
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry config virtualenvs.create false
           poetry install --with dev
       - name: Create directories
         run: |
@@ -524,7 +522,7 @@ jobs:
       - name: Copy pytest ini
         run: cp tests/unit/pytest-ci.ini pytest.ini
       - name: Run Pytest with coverage
-        run: pytest --cov=./ --cov-report=xml --junitxml=test-results/junit.xml tests/unit
+        run: poetry run pytest --cov=./ --cov-report=xml --junitxml=test-results/junit.xml tests/unit
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -458,12 +458,13 @@ jobs:
             pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry lock --check
             poetry export --without-hashes -o package/lib/requirements.txt
-            poetry export --without-hashes --dev -o requirements_dev.txt
+            poetry export --without-hashes --with dev -o requirements_dev.txt
           fi
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry install --with=dev
+          poetry config settings.virtualenvs.create false
+          poetry install --with dev
       - name: Create directories
         run: |
           mkdir -p /opt/splunk/var/log/splunk
@@ -509,12 +510,13 @@ jobs:
             pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry lock --check
             poetry export --without-hashes -o package/lib/requirements.txt
-            poetry export --without-hashes --dev -o requirements_dev.txt
+            poetry export --without-hashes --with dev -o requirements_dev.txt
           fi
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry install --with=dev
+          poetry config settings.virtualenvs.create false
+          poetry install --with dev
       - name: Create directories
         run: |
           mkdir -p /opt/splunk/var/log/splunk
@@ -573,7 +575,7 @@ jobs:
                 echo "No prod dependencies were found"
                 rm requirements.txt
             fi
-            poetry export --without-hashes --dev -o requirements_dev.txt
+            poetry export --without-hashes --with dev -o requirements_dev.txt
             cat requirements_dev.txt
           fi
       - name: Get pip cache dir
@@ -745,7 +747,7 @@ jobs:
                 echo "No prod dependencies were found"
                 rm requirements.txt
             fi
-            poetry export --without-hashes --dev -o requirements_dev.txt
+            poetry export --without-hashes --with dev -o requirements_dev.txt
             cat requirements_dev.txt
           fi
       - id: pip-cache

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -463,7 +463,7 @@ jobs:
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry config settings.virtualenvs.create false
+          poetry config virtualenvs.create false
           poetry install --with dev
       - name: Create directories
         run: |
@@ -515,7 +515,7 @@ jobs:
           if [ ! -f requirements_dev.txt ]; then echo no requirements;exit 0 ;fi
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry config settings.virtualenvs.create false
+          poetry config virtualenvs.create false
           poetry install --with dev
       - name: Create directories
         run: |


### PR DESCRIPTION
Currently in unit tests we install dependencies from requirements_dev.txt file, exported by poetry.

The problem is that this requirements_dev.txt file contains environment markers with supported versions of pythons - this format causes pip to exit silently ans setup step is successful - job is failing later on run-test step which is unexpected.

Changed installation method to `poetry install`

Tests:
https://github.com/splunk/splunk-add-on-for-google-workspace/pull/547
https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1221