### PR TITLE
fix: change k8s-manifest-default-branch (#266)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -17,7 +17,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "main"
+        default: "v1.0.0"
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token


### PR DESCRIPTION
This PR changes default version of ta-automation-k8s-manifests to this tag:
[v1.0.0](https://github.com/splunk/ta-automation-k8s-manifests/releases/tag/v1.0.0)

Tested here: https://github.com/splunk/splunk-add-on-for-mysql/pull/484