### PR TITLE
fix: update AppInspect CLI action to v2.7 (#267)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -862,7 +862,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.6
+        uses: splunk/appinspect-cli-action@v2.7
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
https://github.com/splunk/appinspect-cli-action/releases/tag/v2.7.0 https://github.com/splunk/appinspect-cli-action/pull/128

https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/9017761710