### PR TITLE
chore(release): merge develop to main

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -58,9 +58,14 @@ jobs:
   update-semver:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: publish
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: haya14busa/action-update-semver@v1
+      - uses: splunk/addonfactory-update-semver@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+        with:
+          git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
+          git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
+          gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -264,11 +264,12 @@ jobs:
           submodules: false
           fetch-depth: "0"
           ref: ${{ github.head_ref }}
-      - name: Trufflehog Actions Scan
-        uses: edplato/trufflehog-actions-scan@v0.9l-beta
+      - name: Secret Scanning Trufflehog
+        uses: trufflesecurity/trufflehog@v3.77.0
         with:
-          scanArguments: "--max_dept 5 -x .github/workflows/exclude-patterns.txt --allow .github/workflows/trufflehog-false-positive.json"
-
+          extra_args: -x .github/workflows/exclude-patterns.txt --json
+          version: 3.77.0
+          
   semgrep:
     runs-on: ubuntu-latest
     name: security-sast-semgrep

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1542,13 +1542,13 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} tests artifacts
+          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} tests artifacts
           path: |
             ${{ needs.setup.outputs.directory-path }}/test-results
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} tests logs
+          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} tests logs
           path: |
             ${{ needs.setup.outputs.directory-path }}/argo-logs
       - name: Test Report
@@ -1773,13 +1773,13 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} tests artifacts
+          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} tests artifacts
           path: |
             ${{ needs.setup.outputs.directory-path }}/test-results
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} tests logs
+          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} tests logs
           path: |
             ${{ needs.setup.outputs.directory-path }}/argo-logs
       - name: Test Report

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -4,7 +4,13 @@ on:
     inputs:
       marker:
         required: false
-        description: 'Parallel run marker'
+        description: 'Parallel run mod_input marker'
+        type: string
+        default: >-
+          [""]
+      ui_marker:
+        required: false
+        description: 'Parallel run ui marker'
         type: string
         default: >-
           [""]
@@ -963,7 +969,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v4.0
+        uses: splunk/wfe-test-runner-action@v5.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1195,7 +1201,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v4.0
+        uses: splunk/wfe-test-runner-action@v5.0
         with:
           splunk: ${{ matrix.splunk.version }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1347,7 +1353,7 @@ jobs:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_combinedSplunkversion) }}
         browser: [ "chrome" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
-
+        marker: ${{ fromJson(inputs.ui_marker) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.0.0
     env:
@@ -1359,6 +1365,7 @@ jobs:
       SPLUNK_VERSION_BASE: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
       TEST_TYPE: "ui"
       TEST_ARGS: "--browser ${{ matrix.browser }}"
+      TEST_BROWSER: ${{ matrix.browser }}
     permissions:
       actions: read
       deployments: read
@@ -1402,17 +1409,29 @@ jobs:
           JOB_NAME=${JOB_NAME//[_.:]/-}
           JOB_NAME=$(echo "$JOB_NAME" | tr '[:upper:]' '[:lower:]')
           echo "job-name=$JOB_NAME" >> "$GITHUB_OUTPUT"
+      - name: create test argument
+        id: create-test-arg
+        shell: bash
+        run: |
+          TEST_ARG_M=""
+          EMPTY_MARKER="[]"
+
+          if [[ "${{ inputs.ui_marker }}" != "$EMPTY_MARKER" ]]; then
+            TEST_ARG_M="-m"
+          fi
+
+          echo "test-arg=$TEST_ARG_M" >> "$GITHUB_OUTPUT"
       - name: run-tests
         id: run-tests
         timeout-minutes: 340
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v4.0
+        uses: splunk/wfe-test-runner-action@v5.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
-          test-args: ${{ env.TEST_ARGS }}
+          test-args: ${{ env.TEST_ARGS }} ${{ steps.create-test-arg.outputs.test-arg }} ${{ matrix.marker }}
           job-name: ${{ steps.create-job-name.outputs.job-name }}
           labels: ${{ needs.setup.outputs.labels }}
           workflow-tmpl-name: ${{ needs.setup.outputs.argo-workflow-tmpl-name }}
@@ -1422,6 +1441,7 @@ jobs:
           vendor-version: ${{ matrix.vendor-version.image }}
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
+          test-browser: ${{ env.TEST_BROWSER }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1625,13 +1645,13 @@ jobs:
         id: create-test-arg
         shell: bash
         run: |
-          export comparing_variable="[]"
-          if [ "${{ inputs.marker }}" == "$comparing_variable" ]
-          then
-            TEST_ARG_M=""
-          else
+          TEST_ARG_M=""
+          EMPTY_MARKER="[]"
+
+          if [[ "${{ inputs.marker }}" != "$EMPTY_MARKER" ]]; then
             TEST_ARG_M="-m"
           fi
+      
           echo "test-arg=$TEST_ARG_M" >> "$GITHUB_OUTPUT"
       - name: run-tests
         id: run-tests
@@ -1639,7 +1659,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v4.0
+        uses: splunk/wfe-test-runner-action@v5.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1868,7 +1888,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v4.0
+        uses: splunk/wfe-test-runner-action@v5.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -17,7 +17,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v2.0.0"
+        default: "v3.0.0"
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token
@@ -904,7 +904,7 @@ jobs:
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
 
     container:
-      image: ghcr.io/splunk/workflow-engine-base:3.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.0.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -963,7 +963,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v3.0
+        uses: splunk/wfe-test-runner-action@v4.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1137,7 +1137,7 @@ jobs:
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
 
     container:
-      image: ghcr.io/splunk/workflow-engine-base:3.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.0.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1195,7 +1195,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v3.0
+        uses: splunk/wfe-test-runner-action@v4.0
         with:
           splunk: ${{ matrix.splunk.version }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1349,7 +1349,7 @@ jobs:
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
 
     container:
-      image: ghcr.io/splunk/workflow-engine-base:3.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.0.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1408,7 +1408,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v3.0
+        uses: splunk/wfe-test-runner-action@v4.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1568,7 +1568,7 @@ jobs:
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         marker: ${{ fromJson(inputs.marker) }}
     container:
-      image: ghcr.io/splunk/workflow-engine-base:3.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.0.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1639,7 +1639,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v3.0
+        uses: splunk/wfe-test-runner-action@v4.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1797,7 +1797,7 @@ jobs:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_combinedSplunkversion) }}
         os: [ "ubuntu:14.04", "ubuntu:16.04","ubuntu:18.04","ubuntu:22.04", "centos:7", "redhat:8.0", "redhat:8.2", "redhat:8.3", "redhat:8.4", "redhat:8.5" ]
     container:
-      image: ghcr.io/splunk/workflow-engine-base:3.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.0.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1868,7 +1868,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v3.0
+        uses: splunk/wfe-test-runner-action@v4.0
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}

--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ cim-compliance-report
 **Description**
 
 - This stage does the setup for executing UI tests and reports the results
+- It is possible to parallelize UI tests execution by using pytest markers. 
+  To do so, one must specify `ui_marker` parameter in buid-test-release.yml as in [example](https://github.com/splunk/splunk-add-on-for-amazon-web-services/blob/925fd189737507dd91cc5275c59a8b390550411c/.github/workflows/build-test-release.yml#L35).
+  Markers must be created prior and each test case must be marked (check [run-modinput-tests](#run-modinput-tests), and this [PR](https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1237))
 
 **Action used:** 
 - No action used
@@ -525,6 +528,10 @@ Junit XML file
 **Description**
 
 - This stage does the setup for executing Modinput tests and reports the results
+- It is possible to parallelize Modinput tests execution by using pytest markers. 
+  To do so, one must specify `marker` parameter in buid-test-release.yml as in [example](https://github.com/splunk/splunk-add-on-for-amazon-web-services/blob/603f37ee24565f23104c0297e55a0c72480f34c9/.github/workflows/build-test-release.yml#L33).
+  Markers must be created prior and each test case must be marked (check the following references: [ref1](https://github.com/splunk/splunk-add-on-for-amazon-web-services/blob/main/tests/modinput_functional/README-test.md), 
+[ref2](https://github.com/splunk/splunk-add-on-for-amazon-web-services/blob/main/tests/modinput_functional/centaurs/tacommon/test_ta_mark.py), [ref3](https://github.com/splunk/splunk-add-on-for-amazon-web-services/blob/603f37ee24565f23104c0297e55a0c72480f34c9/tests/modinput_functional/data_collection/aws_s3/test_aws_s3_line_content.py#L20))
 
 **Action used:** 
 - No action

--- a/README.md
+++ b/README.md
@@ -162,15 +162,15 @@ security-detect-secrets
 
 **Description:**
 
-- This action is intended as a Continuous Integration secret scan in an already "clean" repository. The default commit scan depth is the last 50 commits and can be adjusted using Custom Arguments 
+- This action is intended as a Continuous Integration secret scan in an already "clean" repository.
 
-- The stage checks for addition/deletion of any secret/sensitive data in last 50 commits of the repository.
+- The stage checks for addition/deletion of any secret/sensitive data in referenced commits (commits pushed or commits within PR).
 
-**Action used** https://github.com/edplato/trufflehog-actions-scan
+**Action used** https://github.com/trufflesecurity/trufflehog
 
 **Pass/fail behaviour**
 
-- The stage is likely to fail if there is some sensitive or secrets or confidential data had been removed or added in the last 50 commits.
+- The stage is likely to fail if any sensitive secrets or confidential data were removed or added in the referenced commits.
 
 **Troubleshooting steps for failures if any**
 
@@ -178,20 +178,15 @@ security-detect-secrets
 
 **Exception File**
 
-- To ignore the file add the path of the file having the false positive in the `.github/workflows/exclude-patterns.txt`, ideally this should be avoided and only specific false positives should be added in exception files.
+- To ignore the file add the path of the file having the false positive in the `.github/workflows/exclude-patterns.txt`, ideally this should be avoided and only specific false positives should be added in exception files. This is file with newline separated regexes for files to exclude in scan.
 
 - False positives include: public keys, random / dummy session keys or tokens.
 
-- We can use this file `.github/workflows/trufflehog-false-positive.json` from action version `>=v0.9l-beta` to add specific failures or regexes. 
-
-- ref for how to add regex to json file : https://github.com/edplato/trufflehog-actions-scan#usage
-
-- **NOTE:** The usage of `.github/workflows/trufflehog-false-positive.json` is not rolled out yet, PR for feature support: https://github.com/splunk/addonfactory-workflow-addon-release/pull/32
-
+- User can add a `trufflehog:ignore` comment on the line containing the secret to ignore that secrets.
 
 **Artifacts:**
 
-- No additional artifacts, the commit info is available in the logs.
+- No additional artifacts, the commit info and secrets details are available in the logs.
 
 
 security-sast-semgrep

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,5 @@
       ":semanticCommitTypeAll(chore)",
       "schedule:earlyMondays",
       ":disableDependencyDashboard"
-    ],
-    "ignoreDeps": [
-      "edplato/trufflehog-actions-scan"
     ]
 }

--- a/runbooks/publish_multiple_os_images_scripted_inputs.md
+++ b/runbooks/publish_multiple_os_images_scripted_inputs.md
@@ -1,0 +1,12 @@
+# Runbook to publish multiple images of different Linux flavors and versions for scripted inputs tests
+
+Once there is new Splunk release, and [matrix](https://github.com/splunk/addonfactory-test-matrix-action) is updated, we need to make sure that Splunk images for scripted inputs tests are created and published.
+## Steps
+
+### Update OS images
+- check what OS are listed in definition of matrix in scripted inputs tests [here](https://github.com/splunk/addonfactory-workflow-addon-release/blob/v4.16/.github/workflows/reusable-build-test-release.yml#L1966)
+- if any is missing in [ta-automation-docker-images](https://cd.splunkdev.com/taautomation/ta-automation-docker-images/-/tree/main/dockerfiles) then add new Dockerfile
+
+### Create images and publish them to ECR
+- figure out what version of Splunk is needed (sha) using go/fetcher
+- trigger [pipeline](https://cd.splunkdev.com/taautomation/ta-automation-docker-images/-/pipelines/new) for every OS flavor separately


### PR DESCRIPTION
Test runs:
https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/9269557494
https://github.com/splunk/test-addonfactory-repo/actions/runs/9270329208

Changes possibly affecting customers:
- add ui_marker to enable splitting UI tests execution
- fix for failing upload-artifact@v4 due to multiple artifacts with same name
- replace edplato/trufflehog-actions-scan action with official trufflehog action latest release
- bump version of workflow-engine-base image to v4.0 (Ubuntu 20 -> Ubuntu 22)

Changes not affecting customers:
- wfe-test-runner-action update to v5 and change of the way that browser is determined in k8s 
- docs and ci related updates

Also note that starting from release v4.16.0 some assets are removed from TA releases:
1. installation-actions.json
2. installation-update.json
3. \<TA-release\>-_forwarders.spl
4. \<TA-release\>-_indexers.spl
5. \<TA-release\>-_search_heads.spl
