### PR TITLE
fix: update kubectl version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -911,7 +911,7 @@ jobs:
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
 
     container:
-      image: ghcr.io/splunk/workflow-engine-base:4.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.1.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1144,7 +1144,7 @@ jobs:
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
 
     container:
-      image: ghcr.io/splunk/workflow-engine-base:4.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.1.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1356,7 +1356,7 @@ jobs:
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
         marker: ${{ fromJson(inputs.ui_marker) }}
     container:
-      image: ghcr.io/splunk/workflow-engine-base:4.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.1.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1589,7 +1589,7 @@ jobs:
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         marker: ${{ fromJson(inputs.marker) }}
     container:
-      image: ghcr.io/splunk/workflow-engine-base:4.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.1.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
@@ -1818,7 +1818,7 @@ jobs:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_combinedSplunkversion) }}
         os: [ "ubuntu:14.04", "ubuntu:16.04","ubuntu:18.04","ubuntu:22.04", "centos:7", "redhat:8.0", "redhat:8.2", "redhat:8.3", "redhat:8.4", "redhat:8.5" ]
     container:
-      image: ghcr.io/splunk/workflow-engine-base:4.0.0
+      image: ghcr.io/splunk/workflow-engine-base:4.1.0
     env:
       ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
       ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -23,7 +23,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.0.0"
+        default: "v3.0.1"
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token


### PR DESCRIPTION
This PR updates `workflow-engine-base` version from 4.0.0 to 4.1.0 - which in turn updates `kubectl` version from 1.22.0 to 1.28.0. It also bumps k8s-manifests-branch default value ( [check the difference here](https://github.com/splunk/ta-automation-k8s-manifests/compare/v3.0.0...v3.0.1) )
`wfe-test-runner-action` is not being updated in this PR, since it's set to v5.0 (which points to v5.0.1)

The change was required to fix the issue of copying big diag files by adding `--retries` flag, which was not available in version 1.22.0.

Jira: https://splunk.atlassian.net/browse/ADDON-69486 

Test run: https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/9351735473