### PR TITLE
fix: update addonfactory-test-matrix-action version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -190,7 +190,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1.13
+        uses: splunk/addonfactory-test-matrix-action@v2.0.0
       - name: Combined Splunk and SC4S Versions
         id: combined_Splunkmatrix
         run: |


### PR DESCRIPTION
Updated matrix action to v2.0.0

- Tested with mscs: https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/9381867898