### PR TITLE
fix: trufflehog --only-verified

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Secret Scanning Trufflehog
         uses: trufflesecurity/trufflehog@v3.77.0
         with:
-          extra_args: -x .github/workflows/exclude-patterns.txt --json
+          extra_args: -x .github/workflows/exclude-patterns.txt --json --only-verified
           version: 3.77.0
           
   semgrep:


### PR DESCRIPTION
Recently multiple false positives reported for trufflehog v3: https://splunk.slack.com/archives/CRTNPEZ4M/p1717405810934429

Let's add --only-verified flag to callout to avoid multiple fp for now. Final solution need to be established/reviewed with prodsec.