### PR TITLE
fix: setup job install poetry without sudo

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -338,7 +338,7 @@ jobs:
           if [ -f "poetry.lock" ]
           then
             mkdir -p package/lib || true
-            pip install poetry==1.5.1 poetry-plugin-export==1.4.0
+            python${{ matrix.python-version }} -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry lock --check
             poetry export --without-hashes -o package/lib/requirements.txt
             poetry export --without-hashes --with dev -o requirements_dev.txt
@@ -389,7 +389,7 @@ jobs:
           if [ -f "poetry.lock" ]
           then
             mkdir -p package/lib || true
-            pip install poetry==1.5.1 poetry-plugin-export==1.4.0
+            python${{ matrix.python-version }} -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry lock --check
             poetry export --without-hashes -o package/lib/requirements.txt
             poetry export --without-hashes --with dev -o requirements_dev.txt
@@ -437,7 +437,6 @@ jobs:
           # build if this is not set false
           persist-credentials: false
       - name: Setup python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.7
@@ -446,7 +445,7 @@ jobs:
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
-            python${{ steps.setup-python.python-version }} -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
+            python3.7 -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry export --without-hashes -o requirements.txt
             if [ "$(grep -cve '^\s*$' requirements.txt)" -ne 0 ]
             then
@@ -610,7 +609,6 @@ jobs:
           # build if this is not set false
           persist-credentials: false
       - name: Setup python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
@@ -619,7 +617,7 @@ jobs:
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
-            python${{ steps.setup-python.python-version }} -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
+            python3.9 -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry export --without-hashes -o requirements.txt
             if [ "$(grep -cve '^\s*$' requirements.txt)" -ne 0 ]
             then
@@ -870,7 +868,6 @@ jobs:
           name: artifact-openapi
           path: ${{ github.workspace }}
       - name: Setup python
-        id: setup-python
         if: steps.download-openapi.conclusion != 'skipped'
         uses: actions/setup-python@v5
         with:
@@ -881,7 +878,7 @@ jobs:
         env:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          python${{ steps.setup-python.python-version }} -m pip install poetry==1.5.1 
+          python3.7 -m pip install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -878,7 +878,7 @@ jobs:
         env:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          pip install poetry==1.5.1 
+          python3.7 -m pip install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -876,7 +876,7 @@ jobs:
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash
         run: |
-          sudo pip3 install poetry==1.5.1 
+          sudo pip install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -875,8 +875,6 @@ jobs:
       - name: modinput-test-prerequisites
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash
-        env:
-          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
           sudo pip3 install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -882,7 +882,7 @@ jobs:
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}
-          poetry install --only modinput
+          poetry install
           poetry run ucc-test-modinput -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
       - name: upload-swagger-artifacts-to-s3
         if: steps.download-openapi.conclusion != 'skipped'

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -437,6 +437,7 @@ jobs:
           # build if this is not set false
           persist-credentials: false
       - name: Setup python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.7
@@ -445,7 +446,7 @@ jobs:
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
-            sudo pip3 install poetry==1.5.1 poetry-plugin-export==1.4.0
+            python${{ steps.setup-python.python-version }} -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry export --without-hashes -o requirements.txt
             if [ "$(grep -cve '^\s*$' requirements.txt)" -ne 0 ]
             then
@@ -609,6 +610,7 @@ jobs:
           # build if this is not set false
           persist-credentials: false
       - name: Setup python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
@@ -617,7 +619,7 @@ jobs:
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
-            sudo pip3 install poetry==1.5.1 poetry-plugin-export==1.4.0
+            python${{ steps.setup-python.python-version }} -m pip install poetry==1.5.1 poetry-plugin-export==1.4.0
             poetry export --without-hashes -o requirements.txt
             if [ "$(grep -cve '^\s*$' requirements.txt)" -ne 0 ]
             then
@@ -868,6 +870,7 @@ jobs:
           name: artifact-openapi
           path: ${{ github.workspace }}
       - name: Setup python
+        id: setup-python
         if: steps.download-openapi.conclusion != 'skipped'
         uses: actions/setup-python@v5
         with:
@@ -878,7 +881,7 @@ jobs:
         env:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          python3.7 -m pip install poetry==1.5.1 
+          python${{ steps.setup-python.python-version }} -m pip install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -875,12 +875,14 @@ jobs:
       - name: modinput-test-prerequisites
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash
+        env:
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          sudo pip install poetry==1.5.1 
+          pip install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}
-          poetry install
+          poetry install --only modinput
           poetry run ucc-test-modinput -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
       - name: upload-swagger-artifacts-to-s3
         if: steps.download-openapi.conclusion != 'skipped'


### PR DESCRIPTION
`sudo pip3 install poetry` causes issues with dependencies installation as runners `python` is being used instead of `python` checked out in earlier step.
Tests: https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/9612424171