### PR TITLE
fix: update unreleased splunk docker image (#294)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Combined Splunk and SC4S Versions
         id: combined_Splunkmatrix
         run: |
-          splunk='{"version":"unreleased-python3_9-7027496d63d8", "build":"7027496d63d8", "islatest":false, "isoldest":false}'
+          splunk='{"version":"unreleased-python3_9-f8b1a92a256b", "build":"7027496d63d8", "islatest":false, "isoldest":false}'
           combinedSplunkversions=$(echo '${{ steps.matrix.outputs.supportedSplunk }}' | jq --argjson A "$splunk" '. + [$A]')
           echo "combinedSplunkversions=$(echo "$combinedSplunkversions" | jq -c .)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Update image of unreleased splunk with python 3.9 to build https://cd.splunkdev.com/splcore/main/-/tree/f8b1a92a256b (Splunk 9.3)

Tests: 

https://github.com/splunk/splunk-add-on-for-servicenow/actions/runs/9692653841/job/26746592496?pr=741

https://github.com/splunk/splunk-add-on-for-google-cloud-platform/actions/runs/9692491380/job/26746170582?pr=735 To be released as a bugfix.