### PR TITLE
fix: add input for scripted inputs os

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -24,6 +24,12 @@ on:
         description: "branch for k8s manifests to run the tests on"
         type: string
         default: "v3.0.2"
+      scripted-inputs-os-list:
+        required: false
+        description: "list of OS used for scripted input tests"
+        type: string
+        default: >-
+          ["ubuntu:14.04", "ubuntu:16.04","ubuntu:18.04","ubuntu:22.04", "ubuntu:24.04", "redhat:8.4", "redhat:8.5", "redhat:8.6", "redhat:8.8"]
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token
@@ -1816,7 +1822,7 @@ jobs:
       fail-fast: false
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_combinedSplunkversion) }}
-        os: [ "ubuntu:14.04", "ubuntu:16.04","ubuntu:18.04","ubuntu:22.04", "centos:7", "redhat:8.0", "redhat:8.2", "redhat:8.3", "redhat:8.4", "redhat:8.5" ]
+        os: ${{ fromJson(inputs.scripted-inputs-os-list) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0
     env:


### PR DESCRIPTION
List of OSs for scripted inputes tests can be provided as an input to reusable workflow.
Tested: https://github.com/splunk/splunk-add-on-for-unix-and-linux/pull/577