### PR TITLE
fix: bump matrix-action to v2.0.2

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -190,7 +190,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v2.0.0
+        uses: splunk/addonfactory-test-matrix-action@v2.0.2
       - name: Combined Splunk and SC4S Versions
         id: combined_Splunkmatrix
         run: |


### PR DESCRIPTION
bump matrix-action to v2.0.2 which includes sc4s v3.28.0
tests:
https://github.com/splunk/splunk-add-on-for-cisco-esa/pull/440
Report before update (58 KO failures) https://github.com/splunk/splunk-add-on-for-cisco-esa/runs/27652534705
report after update (12 KO failrues) https://github.com/splunk/splunk-add-on-for-cisco-esa/runs/27656994881