### PR TITLE
fix: bump k8s-manifests branch to v3.0.3

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -23,7 +23,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.0.2"
+        default: "v3.0.3"
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token


### PR DESCRIPTION
This release of manifests doubles the CPU for `modinput_functional` tests.

Ref: https://github.com/splunk/ta-automation-k8s-manifests/pull/96