### PR TITLE
feat: add publish for custom version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -14,6 +14,21 @@ on:
         type: string
         default: >-
           [""]
+      custom-version:
+        required: false
+        description: 'Version of release in the form of "x.x.x" string, specified by user instead of automatically generated semantic release'
+        type: string
+        default: ""
+      execute-tests-on-push-to-develop:
+        required: false
+        description: 'Flag to run all tests on push to develop branch'
+        type: string
+        default: 'false'
+      execute-tests-on-push-to-release:
+        required: false
+        description: 'Flag to run all tests on push to release branch'
+        type: string
+        default: 'false'
       k8s-environment:
         required: false
         description: Specifies which environment to use for k8s testing. ["production", "staging"]
@@ -77,6 +92,24 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  validate-custom-version:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.custom-version != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate custom version
+        run: |
+          if [[ ! ${{ github.event.inputs.custom-version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid custom version provided. Please provide a valid semver version."
+            exit 1
+          fi
+
+          git fetch --tags
+          if [ "$(git tag -l 'v${{ github.event.inputs.custom-version }}')" ]; then
+            echo "The provided version already exists. Please provide a unique version."
+            exit 1
+          fi
+          
   setup-workflow:
     runs-on: ubuntu-latest
     outputs:
@@ -140,7 +173,10 @@ jobs:
             fi
             ;;
           "push")
-            if ${{ github.ref_name == 'main' }} || ${{ github.ref_name == 'develop' }} || ${{ github.ref_type == 'tag' }} ; then
+            if ${{ github.ref_name == 'main' }} ||
+            ${{ github.ref_name == 'develop' && inputs.execute-tests-on-push-to-develop == 'true' }} ||
+            ${{ startsWith(github.ref_name, 'release/') && inputs.execute-tests-on-push-to-release == 'true' }} ||
+            ${{ github.ref_type == 'tag' }} ; then
               for test_type in "${TESTSET[@]}"; do
                 EXECUTE_LABELED["$test_type"]="true"
               done
@@ -150,6 +186,13 @@ jobs:
             for test_type in "${TESTSET[@]}"; do
               EXECUTE_LABELED["$test_type"]="true"
             done
+            ;;
+          "workflow_dispatch")
+            if ${{ inputs.custom-version != '' }} ; then
+              for test_type in "${TESTSET[@]}"; do
+                EXECUTE_LABELED["$test_type"]="true"
+              done
+            fi
             ;;
           *)
             echo "No tests were labeled for execution!"
@@ -415,6 +458,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs:
+      - validate-custom-version
       - setup-workflow
       - test-inventory
       - meta
@@ -424,7 +468,7 @@ jobs:
       - semgrep
       - run-unit-tests
       - fossa-scan
-    if: ${{ !cancelled() && (needs.run-unit-tests.result == 'success' || needs.run-unit-tests.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.run-unit-tests.result == 'success' || needs.run-unit-tests.result == 'skipped') && (needs.validate-custom-version.result == 'success' || needs.validate-custom-version.result == 'skipped') }}
     outputs:
       buildname: ${{ steps.buildupload.outputs.name }}
     permissions:
@@ -495,7 +539,7 @@ jobs:
       - name: Determine the version to build
         id: BuildVersion
         run: |
-          INPUT_SEMVER="${{ steps.semantic.outputs.new_release_version }}"
+          INPUT_SEMVER="${{ github.event.inputs.custom-version != '' && github.event.inputs.custom-version || steps.semantic.outputs.new_release_version }}"
           echo "Initial semver ${INPUT_SEMVER}"
           INPUT_PRNUMBER="${{ github.event.number }}"
           SEMVER_REGEX='^v?[0-9]+\.[0-9]+\.[0-9]+$'
@@ -602,6 +646,7 @@ jobs:
   build-3_9:
     runs-on: ubuntu-latest
     needs:
+      - validate-custom-version
       - setup-workflow
       - test-inventory
       - meta
@@ -613,7 +658,8 @@ jobs:
       - fossa-scan
     if: |
       always() &&
-      (needs.run-unit-tests-3_9.result == 'success' || needs.run-unit-tests-3_9.result == 'skipped')
+      (needs.run-unit-tests-3_9.result == 'success' || needs.run-unit-tests-3_9.result == 'skipped') &&
+      (needs.validate-custom-version.result == 'success' || needs.validate-custom-version.result == 'skipped')
     permissions:
       contents: write
       packages: read
@@ -673,7 +719,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - id: BuildVersion
         run: |
-          INPUT_SEMVER="${{ steps.semantic.outputs.new_release_version }}"
+          INPUT_SEMVER="${{ github.event.inputs.custom-version != '' && github.event.inputs.custom-version || steps.semantic.outputs.new_release_version }}"
           echo "Initial semver ${INPUT_SEMVER}"
           INPUT_PRNUMBER="${{ github.event.number }}"
           SEMVER_REGEX='^v?[0-9]+\.[0-9]+\.[0-9]+$'
@@ -1819,7 +1865,10 @@ jobs:
             ${{ needs.setup.outputs.directory-path }}/diag*
 
   run-scripted-input-tests-full-matrix:
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.scripted_inputs == 'true' && ( github.base_ref == 'main' || github.ref_name == 'main' ) && needs.setup-workflow.outputs.execute-scripted_inputs-labeled == 'true' }}
+    if: |
+      ( !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.scripted_inputs == 'true' ) && 
+      ( github.base_ref == 'main' || github.ref_name == 'main' || ( github.ref_name == 'develop' && inputs.execute-tests-on-push-to-develop == 'true' ) || ( startsWith(github.ref_name, 'release/') && inputs.execute-tests-on-push-to-release == 'true' ) ) && 
+      ( needs.setup-workflow.outputs.execute-scripted_inputs-labeled == 'true' )
     needs:
       - build
       - test-inventory
@@ -2044,12 +2093,13 @@ jobs:
             ${{ needs.setup.outputs.directory-path }}/diag*
 
   pre-publish:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.validate-custom-version.result == 'success' }}
     # The following line will rename 'pre-publish' to 'pre-publish-not_main_pr' when PR is created towards main branch
     # It is necessary to avoid confusion caused by githubactions considering pre-publish for both push to develop branch
     # and pull_request to main branch events.
     name: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' &&  'pre-publish' ||  'pre-publish-not_main_pr' }}
     needs:
+      - validate-custom-version
       - meta
       - compliance-copyrights
       - lint
@@ -2086,9 +2136,14 @@ jobs:
           exit 1
 
   publish:
-    if: ${{ !cancelled() && needs.pre-publish.result == 'success' && github.event_name != 'pull_request' && github.event_name != 'schedule' }}
+    if: |
+      (!cancelled() && needs.pre-publish.result == 'success' && github.event_name != 'pull_request' && github.event_name != 'schedule') ||
+      (!cancelled() && needs.pre-publish.result == 'success' && github.event.inputs.custom-version != '' && needs.validate-custom-version.result == 'success')
+    name: ${{ github.event.inputs.custom-version == '' &&  'publish' ||  'publish-custom-version' }}
+
     needs:
       - pre-publish
+      - validate-custom-version
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2102,6 +2157,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - name: Semantic Release
+        if: ${{ github.event.inputs.custom-version  == '' }}
         id: semantic
         uses: splunk/semantic-release-action@v1.3
         env:
@@ -2111,15 +2167,24 @@ jobs:
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}
+      - name: Release custom version
+        if: ${{ github.event.inputs.custom-version  != '' }}
+        id: custom
+        uses: "softprops/action-gh-release@v2"
+        with:
+          token: "${{ secrets.GH_TOKEN_ADMIN }}"
+          tag_name: v${{ github.event.inputs.custom-version }}
+          target_commitish: "${{github.ref_name}}"
+          make_latest: false
       - name: Download package-deployment
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' || steps.custom.outputs.upload_url  != '' }}
         uses: actions/download-artifact@v4
         id: download-package-deployment
         with:
           name: package-deployment
           path: download/artifacts/
       - name: Download package-splunkbase
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' || steps.custom.outputs.upload_url  != '' }}
         uses: actions/download-artifact@v4
         id: download-package-splunkbase
         with:
@@ -2127,7 +2192,7 @@ jobs:
           path: download/artifacts/deployment
       - name: Download cim-compliance-report
         id: download-cim-compliance-report
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' || steps.custom.outputs.upload_url  != '' }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -2135,22 +2200,22 @@ jobs:
           path: download/artifacts/deployment
       - name: Download cim-field-report
         id: download-cim-field-report
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' || steps.custom.outputs.upload_url  != '' }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: cim-field-report
           path: download/artifacts/deployment
       - name: List of assets
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true'|| steps.custom.outputs.upload_url  != '' }}
         run: |
           ls -la ${{ steps.download-package-splunkbase.outputs.download-path }}
       - name: Upload assets to release
-        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' || steps.custom.outputs.upload_url  != '' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ github.token }}
           file: ${{ steps.download-package-splunkbase.outputs.download-path }}/*
           overwrite: true
           file_glob: true
-          tag: v${{ steps.semantic.outputs.new_release_version }}
+          tag: v${{ github.event.inputs.custom-version != '' && github.event.inputs.custom-version || steps.semantic.outputs.new_release_version }}


### PR DESCRIPTION
### Background

In certain scenarios, some clients prefer not to update to the latest version of the software but require critical bug fixes in their current version. This necessitates bypassing the automated versioning provided by semantic-release, allowing for a manually specified version to be released.
### Changes Introduced

In this PR, I've introduced a dispatcher to the workflow, enabling users to specify a custom version when triggering a release. This enhancement provides greater flexibility, particularly for clients who need targeted updates without adopting the latest release.
### Key Implementations:

* Custom-Version Dispatcher: Added a dispatcher that allows users to input a custom version number when initiating a release. This ensures that specific bug fixes can be released independently of the standard semantic-release process.
* Release Workflow: Integrated the release process with softprops/action-gh-release@v2, ensuring a smooth and consistent release experience while accommodating the custom version specified by the user.

### Discussion Point:

Tag Creation and Workflow Rerun: Currently, when a custom version is used and a package is released, the workflow is triggered again because a tag is created. This raises the question: Is it necessary to trigger the workflow with a tag, or should we consider an alternative approach to prevent redundant workflow executions? Feedback on this point would be appreciated.

### Test branch:
[https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/10353886295](https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/10353886295)
### References
Implementation docs: [https://docs.google.com/document/d/1Qenm338CyoeZHo3M_dbX5GJD1SDmlLhz1Jfpg7VWrPg/edit](https://docs.google.com/document/d/1Qenm338CyoeZHo3M_dbX5GJD1SDmlLhz1Jfpg7VWrPg/edit)
GitHub Action: [softprops/action-gh-release@v2](https://github.com/softprops/action-gh-release)