### PR TITLE
refactor: use reusable workflow for semgrep

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -275,7 +275,7 @@ jobs:
     secrets:
       SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
     with:
-      allow_failure: false
+      upload_results: true
 
   test-inventory:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -274,9 +274,6 @@ jobs:
     uses: splunk/sast-scanning/.github/workflows/sast-scan.yml@main
     secrets:
       SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
-    permissions: write-all
-    with:
-      upload_results: true
 
   test-inventory:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -269,19 +269,11 @@ jobs:
         with:
           extra_args: -x .github/workflows/exclude-patterns.txt --json --only-verified
           version: 3.77.0
-          
+
   semgrep:
-    runs-on: ubuntu-latest
-    name: security-sast-semgrep
-    container:
-      image: returntocorp/semgrep
-    steps:
-      - uses: actions/checkout@v4
-      - name: Semgrep
-        id: semgrep
-        run: semgrep ci
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
+    uses: splunk/sast-scanning/.github/workflows/sast-scan.yml@main
+    secrets:
+      SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 
   test-inventory:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -274,6 +274,8 @@ jobs:
     uses: splunk/sast-scanning/.github/workflows/sast-scan.yml@main
     secrets:
       SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
+    with:
+      allow_failure: false
 
   test-inventory:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -274,6 +274,7 @@ jobs:
     uses: splunk/sast-scanning/.github/workflows/sast-scan.yml@main
     secrets:
       SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
+    permissions: write-all
     with:
       upload_results: true
 


### PR DESCRIPTION
Updated the build-test-release workflow to use [sast-scan](https://github.com/splunk/sast-scanning) owned by product security team instead of using custom implementation.
Ref: https://splunk.atlassian.net/browse/ADDON-72309

Test workflow run: https://github.com/splunk/splunk-add-on-for-servicenow/actions/runs/10596615468
Tested on PR: https://github.com/splunk/splunk-add-on-for-servicenow/pull/751

Workflow is not tested for the failure scenario because we need to have blocker findings by the semgrep in order to fail the workflow. Currently all rules are in monitor mode so any findings by the semgrep will be non-blocker resulting in semgrep stage to pass everytime.
Discussion with the semgrep team: https://splunk.slack.com/archives/C011ELTV7FG/p1724923496371529