### PR TITLE
fix: bump k8s manifests branch version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -33,7 +33,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.0.5"
+        default: "v3.0.6"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
This PR bumps `k8s-manifests-branch` version.  It increases requests rate limit for GitHub api. Related PR https://github.com/splunk/ta-automation-k8s-manifests/pull/103
Tested here: https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/10697833642/job/29656542503