### PR TITLE
fix: bump k8s-manifests-branch version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -33,7 +33,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.0.6"
+        default: "v3.0.8"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
This PR bumps `k8s-manifests-branch` version.
It fixes the below items,
- Stopped the diag generation in case of passed tests
- fixed cim-compliance-report generation

Related PRs:
(Stop diag generation)
- https://github.com/splunk/ta-automation-app-of-apps/pull/21
- https://github.com/splunk/ta-automation-k8s-manifests/pull/104
- https://cd.splunkdev.com/workflow-engine/ta/ta-automation-cluster/-/merge_requests/63
(fix cim-compliance-report)
- https://github.com/splunk/ta-automation-k8s-manifests/pull/105


Test workflow run: https://github.com/splunk/splunk-add-on-for-mysql/actions/runs/10767934733/job/29856231470