### PR TITLE
fix: bump k8s manifests branch version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -33,7 +33,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.0.8"
+        default: "v3.0.9"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
This PR bumps the version of k8s-manifests-branch to fix the issue with the diag generation.

related PR: https://github.com/splunk/ta-automation-k8s-manifests/pull/106

test workflow run:
- https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/10631152841
- https://github.com/splunk/splunk-add-on-for-servicenow/actions/runs/10919108085