### PR TITLE
fix: add block_mode input for semgrep

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -324,6 +324,8 @@ jobs:
     uses: splunk/sast-scanning/.github/workflows/sast-scan.yml@main
     secrets:
       SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
+    with:
+      block_mode: "policy"
 
   test-inventory:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds input block_mode for semgrep to enable failing pipeline if we have some findings in semgrep scan.

Test run: https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/10954006775