### PR TITLE
fix: workflow summary for tests results

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1127,7 +1127,7 @@ jobs:
           else
             echo "No retry required"
             argo wait "${{ steps.run-btool-check.outputs.workflow-name }}" -n workflows
-            argo watch "${{ steps.run-btool-check.outputs.workflow-name }}" -n workflows | grep "btool-check"
+            argo watch "${{ steps.run-btool-check.outputs.workflow-name }}" -n workflows | grep "test-btool"
           fi
       - name: check workflow status
         id: check-workflow-status

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2489,26 +2489,12 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            # Initialize counters
-            passed_count=0
-            failed_count=0
-            errored_count=0
-            skipped_count=0
-
-            # Loop through each testcase in the XML
-            while IFS= read -r testcase; do
-              if echo "$testcase" | grep -q "<error"; then
-                errored_count=$((errored_count + 1))
-              elif echo "$testcase" | grep -q "<failure"; then
-                failed_count=$((failed_count + 1))
-              elif echo "$testcase" | grep -q "<skipped"; then
-                skipped_count=$((skipped_count + 1))
-              else
-                passed_count=$((passed_count + 1))
-              fi
-            done < <(xmllint --xpath "//testcase" "$junit_xml_file" 2>/dev/null)
-            total_tests=$((passed_count + failed_count + errored_count + skipped_count))
-            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed_count |$failed_count |$errored_count | $skipped_count |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file" 2>/dev/null)
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file" 2>/dev/null)
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file" 2>/dev/null)
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file" 2>/dev/null)
+            passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
               echo "no XML File found, exiting"
               exit 1

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -402,15 +402,15 @@ jobs:
           junit_xml_file=$(find "test-results" -name "*.xml" -type f 2>/dev/null | head -n 1)
 
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - uses: actions/upload-artifact@v4
         if: success() || failure()
@@ -470,15 +470,15 @@ jobs:
           junit_xml_file=$(find "test-results" -name "*.xml" -type f 2>/dev/null | head -n 1)
 
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - uses: actions/upload-artifact@v4
         if: success() || failure()
@@ -1407,15 +1407,15 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - name: Upload-artifact-for-github-summary
         uses: actions/upload-artifact@v4
@@ -1662,15 +1662,15 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - name: Upload-artifact-for-github-summary
         uses: actions/upload-artifact@v4
@@ -1939,15 +1939,15 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - name: Upload-artifact-for-github-summary
         uses: actions/upload-artifact@v4
@@ -2214,15 +2214,15 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - name: Upload-artifact-for-github-summary
         uses: actions/upload-artifact@v4
@@ -2483,21 +2483,20 @@ jobs:
           reporter: java-junit
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
-        shell: bash
         run: |
           apt-get install -y libxml2-utils
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file" 2>/dev/null)
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file" 2>/dev/null)
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file" 2>/dev/null)
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file" 2>/dev/null)
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
-              echo "no XML File found, exiting"
-              exit 1
+            echo "no XML File found, exiting"
+            exit 1
           fi
       - name: Upload-artifact-for-github-summary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2483,6 +2483,7 @@ jobs:
           reporter: java-junit
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
+        shell: bash
         run: |
           apt-get install -y libxml2-utils
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
@@ -2507,13 +2508,6 @@ jobs:
               fi
             done < <(xmllint --xpath "//testcase" "$junit_xml_file" 2>/dev/null)
             total_tests=$((passed_count + failed_count + errored_count + skipped_count))
-              # total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              # failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              # # errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              # errors=$(xmllint --xpath '//testcase[error]' "$junit_xml_file" 2>/dev/null | \
-              # xmllint --xpath '//testcase/@name' - | tr ' ' '\n' | sort | uniq | wc -l)
-              # skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              # passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed_count |$failed_count |$errored_count | $skipped_count |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
               echo "no XML File found, exiting"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2490,7 +2490,9 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
               total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
               failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
+              # errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
+              errors=$(xmllint --xpath '//testcase[error]' "$junit_xml_file" 2>/dev/null | \
+              xmllint --xpath '//testcase/@name' - | tr ' ' '\n' | sort | uniq | wc -l)
               skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
               passed=$((total_tests - failures - errors - skipped))
               echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2488,14 +2488,33 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              # errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              errors=$(xmllint --xpath '//testcase[error]' "$junit_xml_file" 2>/dev/null | \
-              xmllint --xpath '//testcase/@name' - | tr ' ' '\n' | sort | uniq | wc -l)
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
-              passed=$((total_tests - failures - errors - skipped))
-              echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+            # Initialize counters
+            passed_count=0
+            failed_count=0
+            errored_count=0
+            skipped_count=0
+
+            # Loop through each testcase in the XML
+            while IFS= read -r testcase; do
+              if echo "$testcase" | grep -q "<error"; then
+                errored_count=$((errored_count + 1))
+              elif echo "$testcase" | grep -q "<failure"; then
+                failed_count=$((failed_count + 1))
+              elif echo "$testcase" | grep -q "<skipped"; then
+                skipped_count=$((skipped_count + 1))
+              else
+                passed_count=$((passed_count + 1))
+              fi
+            done < <(xmllint --xpath "//testcase" "$junit_xml_file" 2>/dev/null)
+            total_tests=$((passed_count + failed_count + errored_count + skipped_count))
+              # total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
+              # failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
+              # # errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
+              # errors=$(xmllint --xpath '//testcase[error]' "$junit_xml_file" 2>/dev/null | \
+              # xmllint --xpath '//testcase/@name' - | tr ' ' '\n' | sort | uniq | wc -l)
+              # skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
+              # passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed_count |$failed_count |$errored_count | $skipped_count |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
               echo "no XML File found, exiting"
               exit 1


### PR DESCRIPTION
This PR resolves the issue with the test results summary.
Also, fixed the issue with the `test-btool` workflow status check.

Issue reference:
workflow run: https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/12072808241
check the ucc modinput tests results summary. It shows total number of tests and the errors count as 6. However, if you check the test report, there were only 3 tests ran(each test case had error in the setup and teardown method resulting in 6 errors).

Test workflow: https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/12136591898
