### PR TITLE
fix: deletion of ucc modinput summary artifacts

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2537,7 +2537,7 @@ jobs:
       - uses: geekyeggo/delete-artifact@v5
         with:
             name: |
-                summary-modinput*
+                summary-ucc_modinput*
 
   run-scripted-input-tests-full-matrix:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.scripted_inputs == 'true' && needs.setup-workflow.outputs.execute-scripted_inputs-labeled == 'true' }}


### PR DESCRIPTION
### Description
This PR fixes the issue with the deletion of the result summary artifacts for ucc modinput tests

(PR description goes here)

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releaes test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
