### PR TITLE
chore(deps): upgrade trufflehog to 3.85.0

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -322,7 +322,7 @@ jobs:
           fetch-depth: "0"
           ref: ${{ github.head_ref }}
       - name: Secret Scanning Trufflehog
-        uses: trufflesecurity/trufflehog@v3.84.2
+        uses: trufflesecurity/trufflehog@v3.85.0
         with:
           extra_args: -x .github/workflows/exclude-patterns.txt --json --only-verified
           version: 3.77.0


### PR DESCRIPTION
### Description

This PR upgrades `trufflesecurity/trufflehog` action to `v3.85.0`

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releaes test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
https://github.com/splunk/splunk-add-on-for-cisco-meraki/actions/runs/12201434038/job/34039826531?pr=491