### PR TITLE
fix:stop failing wf when deleting artifacts

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1457,6 +1457,7 @@ jobs:
         with:
             name: |
                 summary-ko*
+            failOnError: false
 
   run-requirement-tests:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.requirement_test == 'true' && needs.setup-workflow.outputs.execute-requirement-labeled == 'true' }}
@@ -1712,6 +1713,7 @@ jobs:
         with:
             name: |
                 summary-requirement*
+            failOnError: false
 
   run-ui-tests:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.ui == 'true' && needs.setup-workflow.outputs.execute-ui-labeled == 'true' }}
@@ -1989,6 +1991,7 @@ jobs:
         with:
             name: |
                 summary-ui*
+            failOnError: false
 
   run-modinput-tests:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.modinput_functional == 'true' && needs.setup-workflow.outputs.execute-modinput-labeled == 'true' }}
@@ -2264,6 +2267,7 @@ jobs:
         with:
             name: |
                 summary-modinput*
+            failOnError: false
 
   run-ucc-modinput-tests:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.ucc_modinput_functional == 'true' && needs.setup-workflow.outputs.execute-ucc-modinput-labeled == 'true' }}
@@ -2538,6 +2542,7 @@ jobs:
         with:
             name: |
                 summary-ucc_modinput*
+            failOnError: false
 
   run-scripted-input-tests-full-matrix:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.scripted_inputs == 'true' && needs.setup-workflow.outputs.execute-scripted_inputs-labeled == 'true' }}
@@ -2806,6 +2811,7 @@ jobs:
         with:
             name: |
                 summary-scripted*
+            failOnError: false
 
   pre-publish:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
### Description

Sometimes `geekyeggo/delete-artifact@v5` fails to delete artifacts which causes the whole pipeline to fail [(example workflow)](https://github.com/splunk/splunk-add-on-for-tomcat/actions/runs/12299124082/job/34327925950). This PR sets the flag `failOnError: false` to prevent this from happening. 
It seems the rootacause is in `geekyeggo/delete-artifact@v5` action - similar issue was already reported: https://github.com/GeekyEggo/delete-artifact/issues/22

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releaes test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
https://github.com/splunk/splunk-add-on-for-tomcat/pull/445