### PR TITLE
fix: update k8s manifests version to fix Splunk deployments cleanup in CI

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.2.0"
+        default: "fix/v3.2.0-add-indexes.conf"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
### Description

This fixes a problem with cleaning up Splunk deployments after tests running in CI. The actual fix is in `ta-automation-k8s-manifests` and in this change we're using the fixed version.
Example workflows with working cleanups:
https://github.com/splunk/splunk-add-on-for-cisco-ucs/actions/runs/12882841443
https://github.com/splunk/splunk-add-on-for-mysql/actions/runs/12882838665