### PR TITLE
fix: deps handling from gh runner to pod

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1015,9 +1015,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           poetry install --only dev
-          libs_archive=libs_$(basename "$BUILD_NAME" .spl)
-          tar -cvf "$libs_archive" $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages")
-          aws s3 sync "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive/" --only-show-errors
+          libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
+          echo "$libs_archive"
+          cp -r $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages") libs/
+          tar -czf "$libs_archive" libs
+          ls -la
+          pwd
+          aws s3 cp "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive" --only-show-errors
       - name: upload-swagger-artifacts-to-s3
         if: steps.download-openapi.conclusion != 'skipped'
         id: swaggerupload

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1009,7 +1009,8 @@ jobs:
           else
             poetry run ucc-test-modinput -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
           fi
-      - id: upload-libs-to-s3
+      - name: upload-libs-to-s3
+        id: upload-libs-to-s3      
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1020,11 +1020,8 @@ jobs:
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           poetry install --with dev
           libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
-          echo "$libs_archive"
-          cp -r $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages") libs/
+          cp -r "$(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages")" libs/
           tar -czf "$libs_archive" libs
-          ls -la
-          pwd
           aws s3 cp "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive" --only-show-errors
       - name: upload-swagger-artifacts-to-s3
         if: steps.download-openapi.conclusion != 'skipped'

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1014,11 +1014,15 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           poetry install --only dev
-          libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
+          libs_archive=venv_$(basename "$BUILD_NAME" .spl).tgz
           echo "$libs_archive"
-          cp -r $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages") libs/
-          tar -czf "$libs_archive" libs
+          mkdir -p venv/bin && mkdir -p venv/lib
+          cp -r "$(poetry env info --path)"/lib/. venv/lib/
+          cp -r "$(poetry env info --path)"/bin/. venv/bin/
+          tar -czf "$libs_archive" venv
           ls -la
           pwd
           aws s3 cp "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive" --only-show-errors

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1009,6 +1009,10 @@ jobs:
             poetry run ucc-test-modinput -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
           fi
       - id: upload-libs-to-s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           poetry install --only dev
           libs_archive=libs_$(basename "$BUILD_NAME" .spl)

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1014,15 +1014,11 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           poetry install --only dev
-          libs_archive=venv_$(basename "$BUILD_NAME" .spl).tgz
+          libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
           echo "$libs_archive"
-          mkdir -p venv/bin && mkdir -p venv/lib
-          cp -r "$(poetry env info --path)"/lib/. venv/lib/
-          cp -r "$(poetry env info --path)"/bin/. venv/bin/
-          tar -czf "$libs_archive" venv
+          cp -r $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages") libs/
+          tar -czf "$libs_archive" libs
           ls -la
           pwd
           aws s3 cp "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive" --only-show-errors

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.3.1"
+        default: "v3.4"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -989,13 +989,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.7
+      - id: setup-poetry
+        shell: bash
+        run: |
+          python3.7 -m pip install poetry==1.5.1 
       - name: modinput-test-prerequisites
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash
         env:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          python3.7 -m pip install poetry==1.5.1 
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}
@@ -1005,6 +1008,12 @@ jobs:
           else
             poetry run ucc-test-modinput -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
           fi
+      - id: upload-libs-to-s3
+        run: |
+          poetry install --only dev
+          libs_archive=libs_$(basename "$BUILD_NAME" .spl)
+          tar -cvf "$libs_archive" $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages")
+          aws s3 sync "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive/" --only-show-errors
       - name: upload-swagger-artifacts-to-s3
         if: steps.download-openapi.conclusion != 'skipped'
         id: swaggerupload

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1014,6 +1014,8 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           poetry install --only dev
           libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
           echo "$libs_archive"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1016,7 +1016,7 @@ jobs:
         run: |
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry install --only dev
+          poetry install --with dev
           libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
           echo "$libs_archive"
           cp -r $(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages") libs/

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -989,7 +989,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.7
-      - id: setup-poetry
+      - name: setup-poetry
+        id: setup-poetry
         shell: bash
         run: |
           python3.7 -m pip install poetry==1.5.1 


### PR DESCRIPTION
### Description

This PR is addressing issue with deps installation when multiple pods are trying to install deps in the same time:
https://splunk.atlassian.net/browse/ADDON-78266

To be reviewed together with: https://github.com/splunk/ta-automation-k8s-manifests/pull/116

virtual environment is first build on github runner filesystem, site-packages are passed to aws s3, and finally downloaded directly to the empty venv on pods filesystem.
### Checklist

- [x] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13140796010/job/36787923223
https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/13153265349/job/36784656491