### PR TITLE
fix: setup job to suport ssh github path in poetry

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -978,6 +978,10 @@ jobs:
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}
+
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
+
           poetry install --only modinput
           if [ -f "tests/ucc_modinput_functional/tmp/openapi.json" ]; then
             poetry run ucc-test-modinput -o tests/ucc_modinput_functional/tmp/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1003,10 +1003,8 @@ jobs:
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}
-
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-
           poetry install --only modinput
           if [ -f "tests/ucc_modinput_functional/tmp/openapi.json" ]; then
             poetry run ucc-test-modinput -o tests/ucc_modinput_functional/tmp/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
@@ -1020,8 +1018,6 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           poetry install --with dev
           libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
           cp -r "$(find "$(poetry env info --path)" -maxdepth 3 -type d -name "site-packages")" libs/


### PR DESCRIPTION
### Description

Reusable workflow fails in setup -> `modinput-test-prerequisites` ignores `ssh://` protocol in poetry.lock/pyproject.toml

```
[tool.poetry.group.modinput.dependencies]
splunk_add_on_ucc_modinput_test = {git = "ssh://git@github.com/splunk/addonfactory-ucc-test.git", tag = "v0.2.0"}
pytest-xdist = ">=3.5.0"
```

Example Job:
https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13052937673/job/36605381881


```
  HangupException

  The remote server unexpectedly closed the connection.

  at /opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/dulwich/protocol.py:215 in read_pkt_line
      211│ 
      212│         try:
      213│             sizestr = read(4)
      214│             if not sizestr:
    → 215│                 raise HangupException
      216│             size = int(sizestr, 16)
      217│             if size == 0 or size == 1:  # flush-pkt or delim-pkt
      218│                 if self.report_activity:
      219│                     self.report_activity(4, "read")

The following error occurred when trying to handle this error:


  HangupException

  git@github.com: Permission denied (publickey).
```



### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [x] workflow errors/warnings reviewed and addressed

### Testing done
PR using WF from branch `fix/setup_poetry_github`
https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1401

Job https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13198332408/job/36845360655?pr=1401
