### PR TITLE
fix: add apt-get update to upgrade tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2588,6 +2588,7 @@ jobs:
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
+          sudo apt-get update
           apt-get install -y libxml2-utils
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)


### PR DESCRIPTION
### Description

Fix missng for upgrade tests: https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13251113562/job/36989972917
### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
