### PR TITLE
chore: run appinspect api on release branches

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -881,7 +881,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.build.result == 'success' &&
-      ( github.base_ref == 'main' || github.ref_name == 'main' || startsWith(github.ref_name, 'release/') )
+      ( github.base_ref == 'main' || github.ref_name == 'main' || startsWith(github.base_ref, 'release/') || startsWith(github.ref_name, 'release/') )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -881,7 +881,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.build.result == 'success' &&
-      ( github.base_ref == 'main' || github.ref_name == 'main' )
+      ( github.base_ref == 'main' || github.ref_name == 'main' || startsWith(github.ref_name, 'release/') )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Description
Run `appinspect api` job for `release/` branches in `build-test-release` pipeline
Ticket: https://splunk.atlassian.net/browse/ADDON-77779

Tested in the following cases where appinspect api job is:
- Running for PR with “release/“ base: https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/13626390125
- Running for manual trigger on “release/“ branch: https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/13626413937
- Not running for chore/ branch: https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/13626445165

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
