### PR TITLE
fix: wfe tests run on splunk latest

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -54,7 +54,7 @@ on:
           [""]
       wfe-run-on-splunk-latest:
         required: false
-        description: "Forces WFE tests to run only on the latest Splunk when set to true. When set to false - will run on all supported Splunk versions required for the release. the When not set - default behavior."
+        description: "Forces WFE tests to run only on the latest Splunk when set to true. When set to false - will run on all supported Splunk versions required for the release. When not set - default behavior."
         type: string
         default: ""
     secrets:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -52,6 +52,11 @@ on:
         type: string
         default: >-
           [""]
+      wfe-run-on-splunk-latest:
+        required: false
+        description: "Forces WFE tests to run only on the latest Splunk when set to true. When set to false - will run on all supported Splunk versions required for the release. the When not set - default behavior."
+        type: string
+        default: ""
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token
@@ -269,15 +274,20 @@ jobs:
       - id: matrix
         uses: splunk/addonfactory-test-matrix-action@v3.0
       - id: determine_splunk
+        env:
+          wfe_run_on_splunk_latest: ${{ inputs.wfe-run-on-splunk-latest }}
         run: |
-          if [ "${{ github.event_name }}" == "schedule" ]; then
+          if [[ "$wfe_run_on_splunk_latest" == "" ]]; then
+            wfe_run_on_splunk_latest="${{  github.event_name == 'schedule' || !((github.base_ref == 'main' || github.ref_name == 'main') || ((github.base_ref == 'develop' || github.ref_name == 'develop')  && github.event_name == 'push')) }}"
+          fi
+          if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
             echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
           else
             echo "matrixSplunk=${{toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
           fi
       - name: job summary
         run: |
-          splunk_version_list=$(echo '${{ steps.matrix.outputs.supportedSplunk }}' | jq -r '.[].version')
+          splunk_version_list=$(echo '${{ steps.determine_splunk.outputs.matrixSplunk }}' | jq -r '.[].version')
           sc4s_version_list=$(echo '${{ steps.matrix.outputs.supportedSC4S }}' | jq -r '.[].version')
           echo -e "## Summary of Versions Used\n- **Splunk versions used:** (${splunk_version_list})\n- **SC4S versions used:** (${sc4s_version_list})\n- Browser: Chrome" >> "$GITHUB_STEP_SUMMARY"
   fossa-scan:


### PR DESCRIPTION
### Description

## Allow for TA to specify Splunk Latest as the only version to run WFE tests against.

It is too expensive to run all WFE tests on all supported Splunk versions on every commit in CDC add-ons on every commit / PR. Let TA to specify the condition to run WFE tests on latest only. 

* Full run takes 2d 20h 31m 27s https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13389640676/usage
* Latest run takes 17h 29m 24s https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13478849153/usage

## Proposal
Default condition - Run WFE tests on all Splunk Versions for conditions:
   *  push to main, develop
   * PR to main

Run only on Splunk latest when:
   * scheduled execution
   * Everything else

Introduce `wfe-run-on-splunk-latest` input for TA to be precise when it needs a custom rule to run or not run on latest

## +Fix
`Summary of Versions Used` should take its value from `steps.determine_splunk.outputs.matrixSplunk`

### Checklist

- [ ] `README.md` has been updated or is not required
- [x] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
