### PR TITLE
fix: fix parsing junit xml in upgrade tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2588,7 +2588,7 @@ jobs:
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
-          sudo apt-get update
+          apt-get update
           apt-get install -y libxml2-utils
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)


### PR DESCRIPTION
Fix for failing `Parse JUnit XML` job in upgrade tests.