### PR TITLE
fix: skip automatic upgrade tests execution on PRs to main

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -51,7 +51,7 @@ on:
         description: "List with TA versions (in 'X.X.X' format) that should be used as starting points for upgrade tests. Example: ['7.6.0', '7.7.0']"
         type: string
         default: >-
-          []
+          [""]
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -51,7 +51,7 @@ on:
         description: "List with TA versions (in 'X.X.X' format) that should be used as starting points for upgrade tests. Example: ['7.6.0', '7.7.0']"
         type: string
         default: >-
-          ["latest"]
+          []
     secrets:
       GH_TOKEN_ADMIN:
         description: Github admin token

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -48,8 +48,7 @@ on:
           ["ubuntu:14.04", "ubuntu:16.04","ubuntu:18.04","ubuntu:22.04", "ubuntu:24.04", "redhat:8.4", "redhat:8.5", "redhat:8.6", "redhat:8.8"]
       upgrade-tests-ta-versions:
         required: false
-        description: "List with TA versions (in 'X.X.X' format) that should be used as starting points for upgrade tests. If not provided,
-          the latest TA version will be used. Example: ['7.6.0', '7.7.0']"
+        description: "List with TA versions (in 'X.X.X' format) that should be used as starting points for upgrade tests. Example: ['7.6.0', '7.7.0']"
         type: string
         default: >-
           ["latest"]
@@ -2354,7 +2353,7 @@ jobs:
             summary-ucc_modinput*
 
   run-upgrade-tests:
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.upgrade == 'true' }}
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.test-inventory.outputs.upgrade == 'true' && needs.setup-workflow.outputs.execute-upgrade-labeled == 'true' }}
     needs:
       - build
       - test-inventory


### PR DESCRIPTION
### Description

Upgrade tests exclusions for automatic execution on PRs to main, etc. (defined here: https://github.com/splunk/addonfactory-workflow-addon-release/blob/main/.github/workflows/reusable-build-test-release.yml#L176) were not working because the condition for `run-upgrade-tests` job added in this PR was missing.

Running upgrade tests automatically on all events the same way as other test types is not desired right now. As per current design, upgrade tests should be executed only when explicitly specified - by assigning `execute_upgrade` label.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
- all tests (including upgrade tests) automatically executed before implementing the fix: https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/13540341896
- all tests (except upgrade tests) automatically executed after implementing the fix: https://github.com/splunk/splunk-add-on-for-google-cloud-platform/actions/runs/13545440706

