### PR TITLE
fix: fix labeled execution for upgrade tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -126,7 +126,7 @@ jobs:
       execute-modinput-labeled: ${{ steps.configure-tests-on-labels.outputs.execute_modinput_functional_labeled }}
       execute-ucc-modinput-labeled: ${{ steps.configure-tests-on-labels.outputs.execute_ucc_modinput_functional_labeled }}
       execute-scripted_inputs-labeled: ${{ steps.configure-tests-on-labels.outputs.execute_scripted_inputs_labeled }}
-      execute-upgrade-labeled: ${{ steps.configure-tests-on-labels.outputs.execute_upgrade_test_labeled }}
+      execute-upgrade-labeled: ${{ steps.configure-tests-on-labels.outputs.execute_upgrade_labeled }}
       exit-first: ${{ steps.configure-tests-on-labels.outputs.exit-first }}
       s3_bucket_k8s: ${{ steps.k8s-environment.outputs.s3_bucket }}
       argo_server_domain_k8s: ${{ steps.k8s-environment.outputs.argo_server_domain }}


### PR DESCRIPTION
### Description

Upgrade tests execution based on labels wasn't configured properly.  Due to variable name of the job output being incorrect, the upgrade tests were not executed when the `execute_upgrade` label was assigned to the PR.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
- workflow without the fix - upgrade tests **not executed** with `execute_upgrade` label assigned: https://github.com/splunk/splunk-add-on-for-google-cloud-platform/pull/798/checks?sha=7797eec5e91a83687fd47ab458d641ac25fcb131
- workflow after the fix - upgrade tests **executed properly** with `execute_upgrade` label assigned: https://github.com/splunk/splunk-add-on-for-google-cloud-platform/pull/798/checks?sha=cb6b6febff5f5580fa44ccab1c6c0a79b21d454e
