### PR TITLE
feat: adding docs change validation step in reuseable CI

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -326,6 +326,8 @@ jobs:
     runs-on: ubuntu-latest  
     container:
       image: python:3.9
+    outputs:
+      status: ${{ steps.validate.outputs.status }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -336,8 +338,26 @@ jobs:
           pip install pip -U
           pip install mkdocs==1.6.1 mkdocs-material==9.6.9 poetry
       - name: validate
+        id: validate
         run: |
-          poetry run mkdocs build --strict
+          if poetry run mkdocs build --strict; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "status :: success"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "status :: failure"
+          fi
+
+  enforce-docs-checks:
+    runs-on: ubuntu-latest  
+    needs: validate-docs-change
+    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    steps:
+      - name: Fail if validate-docs-change failed
+        run: |
+          if [ "${{ needs.validate-docs-change.outputs.status }}" == "failure" ]; then
+            exit 1
+          fi
 
   fossa-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -323,7 +323,9 @@ jobs:
           echo -e "## Summary of Versions Used\n- **Splunk versions used:** (${splunk_version_list})\n- **SC4S versions used:** (${sc4s_version_list})\n- Browser: Chrome" >> "$GITHUB_STEP_SUMMARY"
   
   validate-docs-change:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest  
+    container:
+      image: python:3.9
     steps:
       - uses: actions/checkout@v4
         with:
@@ -332,29 +334,10 @@ jobs:
       - name: Installing requirements
         run: |
           pip install pip -U
-          pip install mkdocs==1.6.1 mkdocs-material==9.6.9
+          pip install mkdocs==1.6.1 mkdocs-material==9.6.9 poetry
       - name: validate
         run: |
-          set -o xtrace
-          if [ -f "mkdocs.yml" ]; then
-            # Run mkdocs serve in the background and redirect output to /tmp/log
-            nohup mkdocs serve &> /tmp/log &
-            pid=$!
-            sleep 5
-
-            # Send SIGTERM to the mkdocs serve process and signal it to terminate
-            kill -TERM $pid
-          else
-            echo "mkdocs.yaml not found. Skipping mkdocs serve."
-            exit 0
-          fi
-
-      - name: check logs
-        if: failure()
-        run: |
-          echo -e "\033[33m⚠️ mkdocs serve exited with an error. Here are logs from mkdocs serve \033[0m"
-          set -o xtrace
-          cat /tmp/log
+          poetry run mkdocs build --strict
 
   fossa-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -321,6 +321,41 @@ jobs:
           splunk_version_list=$(echo '${{ steps.determine_splunk.outputs.matrixSplunk }}' | jq -r '.[].version')
           sc4s_version_list=$(echo '${{ steps.matrix.outputs.supportedSC4S }}' | jq -r '.[].version')
           echo -e "## Summary of Versions Used\n- **Splunk versions used:** (${splunk_version_list})\n- **SC4S versions used:** (${sc4s_version_list})\n- Browser: Chrome" >> "$GITHUB_STEP_SUMMARY"
+  
+  validate-docs-change:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+          persist-credentials: false
+      - name: Installing requirements
+        run: |
+          pip install pip -U
+          pip install mkdocs==1.6.1 mkdocs-material==9.6.9
+      - name: validate
+        run: |
+          set -o xtrace
+          if [ -f "mkdocs.yml" ]; then
+            # Run mkdocs serve in the background and redirect output to /tmp/log
+            nohup mkdocs serve &> /tmp/log &
+            pid=$!
+            sleep 5
+
+            # Send SIGTERM to the mkdocs serve process and signal it to terminate
+            kill -TERM $pid
+          else
+            echo "mkdocs.yaml not found. Skipping mkdocs serve."
+            exit 0
+          fi
+
+      - name: check logs
+        if: failure()
+        run: |
+          echo -e "\033[33m⚠️ mkdocs serve exited with an error. Here are logs from mkdocs serve \033[0m"
+          set -o xtrace
+          cat /tmp/log
+
   fossa-scan:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -3012,7 +3012,7 @@ jobs:
               echo "run-publish=false" >> "$GITHUB_OUTPUT"
               echo "Publish conditions are not met."
           fi
-          if [[ ${{ github.base_ref == 'main' }} && "${{ needs.enforce-docs-checks.result }}" != "success" ]]
+          if ${{ github.base_ref == 'main' }} && ${{ needs.enforce-docs-checks.result != 'success' }};
           then
             echo " There are documentation changes that break mkdocs deploy. please check validate-docs-change step."
             exit 1

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2994,6 +2994,7 @@ jobs:
       - run-ucc-modinput-tests
       - run-ui-tests
       - validate-pr-title
+      - enforce-docs-checks
     runs-on: ubuntu-latest
     env:
       NEEDS: ${{ toJson(needs) }}
@@ -3010,6 +3011,11 @@ jobs:
           else
               echo "run-publish=false" >> "$GITHUB_OUTPUT"
               echo "Publish conditions are not met."
+          fi
+          if [[ ${{ github.base_ref == 'main' }} && "${{ needs.enforce-docs-checks.result }}" != "success" ]]
+          then
+            echo " There are documentation changes that break mkdocs deploy. please check validate-docs-change step."
+            exit 1
           fi
 
   publish:


### PR DESCRIPTION
### Description

Added a new job validate-docs-change.
This job will attempt to serve the documentation and fail if there are any errors.
If errors occur, they will be printed in the check logs step.

Another stage, enforce-docs-changes, reviews the result of validate-docs-change and uses run metadata to determine whether the job should fail the pipeline.

When the PR targets the main branch, enforce-docs-changes will enforce failure on broken documentation and block merge.
For other branches, it serves as an indicator of documentation issues without blocking the merge.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
