### PR TITLE
fix: mitigate selenium pull rate limits

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.3.2"
+        default: "v3.3.3"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
### Description

Bump version of k8s-manifests to the version with fix for selenium pull rates issues
tests: https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1460

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
