### PR TITLE
Revert "feat: adding docs change validation step in reuseable CI (#390)"

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -321,44 +321,6 @@ jobs:
           splunk_version_list=$(echo '${{ steps.determine_splunk.outputs.matrixSplunk }}' | jq -r '.[].version')
           sc4s_version_list=$(echo '${{ steps.matrix.outputs.supportedSC4S }}' | jq -r '.[].version')
           echo -e "## Summary of Versions Used\n- **Splunk versions used:** (${splunk_version_list})\n- **SC4S versions used:** (${sc4s_version_list})\n- Browser: Chrome" >> "$GITHUB_STEP_SUMMARY"
-  
-  validate-docs-change:
-    runs-on: ubuntu-latest  
-    container:
-      image: python:3.9
-    outputs:
-      status: ${{ steps.validate.outputs.status }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: false
-          persist-credentials: false
-      - name: Installing requirements
-        run: |
-          pip install pip -U
-          pip install mkdocs==1.6.1 mkdocs-material==9.6.9 poetry
-      - name: validate
-        id: validate
-        run: |
-          if poetry run mkdocs build --strict; then
-            echo "status=success" >> "$GITHUB_OUTPUT"
-            echo "status :: success"
-          else
-            echo "status=failure" >> "$GITHUB_OUTPUT"
-            echo "status :: failure"
-          fi
-
-  enforce-docs-checks:
-    runs-on: ubuntu-latest  
-    needs: validate-docs-change
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
-    steps:
-      - name: Fail if validate-docs-change failed
-        run: |
-          if [ "${{ needs.validate-docs-change.outputs.status }}" == "failure" ]; then
-            exit 1
-          fi
-
   fossa-scan:
     runs-on: ubuntu-latest
     steps:
@@ -2994,7 +2956,6 @@ jobs:
       - run-ucc-modinput-tests
       - run-ui-tests
       - validate-pr-title
-      - enforce-docs-checks
     runs-on: ubuntu-latest
     env:
       NEEDS: ${{ toJson(needs) }}
@@ -3011,11 +2972,6 @@ jobs:
           else
               echo "run-publish=false" >> "$GITHUB_OUTPUT"
               echo "Publish conditions are not met."
-          fi
-          if ${{ github.base_ref == 'main' }} && ${{ needs.enforce-docs-checks.result != 'success' }};
-          then
-            echo " There are documentation changes that break mkdocs deploy. please check validate-docs-change step."
-            exit 1
           fi
 
   publish:


### PR DESCRIPTION
This reverts commit e30a82125a96eb0c8010c5c81b133e95106ee06b.

### Description

This PR reverts the previous implementation of documentation validation and enforcement, and reintroduces those capabilities using a **reusable GitHub Actions workflow** along with a **template `validate-deploy-docs.yml` workflow file** in the template repository.

## Changes with PR reference

- Removes the hardcoded docs validation logic.
- Changes related to document validation and deployment is made in this PR: https://github.com/splunk/addonfactory-repository-template/pull/743

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
