### PR TITLE
fix: add adjustments to ucc-test-modinput interface

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1000,9 +1000,9 @@ jobs:
         run: |
           poetry install --only modinput
           if [ -f "tests/ucc_modinput_functional/tmp/openapi.json" ]; then
-            poetry run ucc-test-modinput -o tests/ucc_modinput_functional/tmp/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
+            poetry run ucc-test-modinput gen -o tests/ucc_modinput_functional/tmp/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
           else
-            poetry run ucc-test-modinput -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
+            poetry run ucc-test-modinput gen -o ${{ steps.download-openapi.outputs.download-path }}/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
           fi
       - name: upload-libs-to-s3
         id: upload-libs-to-s3


### PR DESCRIPTION
### Description

This is an adaptation to the new interface of the `ucc-test-modinput` command. From now on `ucc-test-modinput` does not perform `ucc-test-modinput gen` by default, so it must be explicitly specified.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
- [X] backward compatibility (versions lower than 1.0.0): https://github.com/splunk/splunk-add-on-for-google-cloud-platform/actions/runs/15323624242
- [X] latest framework version (version 1.0.0):  https://github.com/splunk/splunk-add-on-for-box/actions/runs/15325196621/job/43118599310