### PR TITLE
fix: adjust k8s to ucc modinput tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.3.3"
+        default: "v3.3.4"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
### Description

This PR bumps k8s repository version. 
k8s changes are related to vendor installation for ucc modinput tests. 
Full Changelog: https://github.com/splunk/ta-automation-k8s-manifests/compare/v3.3.3...v3.3.4

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 

- https://github.com/splunk/splunk-add-on-for-tomcat/actions/runs/15702434384

- https://github.com/splunk/splunk-add-on-for-palo-alto-networks/actions/runs/15702466025
