### PR TITLE
fix: skip running tests on changes in validate-deploy-docs.yaml

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Fetch all refs
         run: git fetch --prune --unshallow
 
-      - name: Check if the changes are only in docs/*, mkdocs.yml, .github/workflows/docs.yml or .github/workflows/validate-deploy-docs.yaml
+      - name: Check if the changes are only in docs/*, mkdocs.yml or .github/workflows/validate-deploy-docs.yaml
         id: check
         run: |
           set -o xtrace


### PR DESCRIPTION
### Description
- Since we now have a new validate-deploy-docs.yaml workflow for documentation, we are including it in the list of files considered as documentation-only changes. This ensures that test cases will not be triggered when only documentation workflows are modified.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done for test addon repo
https://github.com/splunk/test-addonfactory-repo/actions/runs/15874408448/job/44758591172?pr=349
