### PR TITLE
feat(slim): notify devs that slim is no longer needed

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -122,6 +122,18 @@ jobs:
             exit 1
           fi
 
+  check-slim-exists:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if grep -q 'splunk-packaging-toolkit' poetry.lock; then
+            echo "\"splunk-packaging-toolkit\" is no longer needed to be present as a dev dependency, it can be removed. To remove it, run - \"poetry remove --group dev splunk-packaging-toolkit\"."
+            exit 1
+          else
+            exit 0
+          fi
+
   check-docs-changes:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
### Description

This PR suggests devs to remove `splunk-packaging-toolkit` from their dev dependencies.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
* https://github.com/splunk/splunk-add-on-for-mysql/pull/537 - when there is no `slim` - the job does not fail
* https://github.com/splunk/splunk-add-on-for-mysql/pull/539 - when there is `slim` - then job fails
