### PR TITLE
fix: bump k8s manifests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.5.1"
+        default: "v3.6.1"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
### Description
This PR bumps the k8s-manifessts-branch from v3.5.1 to v3.6.1. It contains the following changs
- Updates in the env variable for sc4s setup for compatibility with v3.37.0
- New argument `ta-version` added in the pre-upgrade tests 

### Checklist

- [x] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 

- https://github.com/splunk/splunk-add-on-for-google-cloud-platform/actions/runs/16213562635
- https://github.com/splunk/splunk-add-on-for-microsoft-office-365/actions/runs/16213242733
(failures in the upgrade tests are not due to changes. Changes just affect the sc4s setup and pre-upgrade test execution and they are getting executed.)
