### PR TITLE
fix: Resolve discrepancies in test outcome counting

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -482,12 +482,12 @@ jobs:
           junit_xml_file=$(find "test-results" -name "*.xml" -type f 2>/dev/null | head -n 1)
 
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
-            echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
+            echo -e "| (new parsing) Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "no XML File found, exiting"
             exit 1
@@ -551,12 +551,12 @@ jobs:
           junit_xml_file=$(find "test-results" -name "*.xml" -type f 2>/dev/null | head -n 1)
 
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
-            echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
+            echo -e "| (new parsing) Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "no XML File found, exiting"
             exit 1
@@ -1516,10 +1516,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -1555,7 +1555,7 @@ jobs:
           pattern: summary-ko*
       - name: Combine summaries into a table
         run: |
-          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-ko*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -1794,10 +1794,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -1833,7 +1833,7 @@ jobs:
           pattern: summary-ui*
       - name: Combine summaries into a table
         run: |
-          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-ui-*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2070,10 +2070,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2109,7 +2109,7 @@ jobs:
           pattern: summary-modinput*
       - name: Combine summaries into a table
         run: |
-          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-modinput*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2345,10 +2345,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2384,7 +2384,7 @@ jobs:
           pattern: summary-ucc_modinput*
       - name: Combine summaries into a table
         run: |
-          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-ucc_modinput*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2609,10 +2609,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
-            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
-            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.ta-version-from-upgrade }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2648,7 +2648,7 @@ jobs:
           pattern: summary-upgrade*
       - name: Combine summaries into a table
         run: |
-          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-upgrade*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2878,10 +2878,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
+              total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
+              failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
+              errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
+              skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
               passed=$((total_tests - failures - errors - skipped))
               echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2917,7 +2917,7 @@ jobs:
           pattern: summary-scripted*
       - name: Combine summaries into a table
         run: |
-          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-scripted*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -482,10 +482,10 @@ jobs:
           junit_xml_file=$(find "test-results" -name "*.xml" -type f 2>/dev/null | head -n 1)
 
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -551,10 +551,10 @@ jobs:
           junit_xml_file=$(find "test-results" -name "*.xml" -type f 2>/dev/null | head -n 1)
 
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -1516,10 +1516,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -1794,10 +1794,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2070,10 +2070,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2345,10 +2345,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2609,10 +2609,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-            total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.ta-version-from-upgrade }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2878,10 +2878,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
-              errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
+              total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+              failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+              errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+              skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
               passed=$((total_tests - failures - errors - skipped))
               echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -487,7 +487,7 @@ jobs:
             errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
             skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
-            echo -e "| (new parsing) Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
+            echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "no XML File found, exiting"
             exit 1
@@ -556,7 +556,7 @@ jobs:
             errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
             skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
-            echo -e "| (new parsing) Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
+            echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "no XML File found, exiting"
             exit 1
@@ -1555,7 +1555,7 @@ jobs:
           pattern: summary-ko*
       - name: Combine summaries into a table
         run: |
-          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-ko*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -1833,7 +1833,7 @@ jobs:
           pattern: summary-ui*
       - name: Combine summaries into a table
         run: |
-          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-ui-*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2109,7 +2109,7 @@ jobs:
           pattern: summary-modinput*
       - name: Combine summaries into a table
         run: |
-          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-modinput*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2384,7 +2384,7 @@ jobs:
           pattern: summary-ucc_modinput*
       - name: Combine summaries into a table
         run: |
-          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-ucc_modinput*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2648,7 +2648,7 @@ jobs:
           pattern: summary-upgrade*
       - name: Combine summaries into a table
         run: |
-          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-upgrade*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
@@ -2917,7 +2917,7 @@ jobs:
           pattern: summary-scripted*
       - name: Combine summaries into a table
         run: |
-          echo "| (new parsing) Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
           for file in summary-scripted*/job_summary.txt; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -483,9 +483,9 @@ jobs:
 
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -552,9 +552,9 @@ jobs:
 
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -1517,9 +1517,9 @@ jobs:
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -1795,9 +1795,9 @@ jobs:
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2071,9 +2071,9 @@ jobs:
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2346,9 +2346,9 @@ jobs:
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2610,9 +2610,9 @@ jobs:
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-            failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-            errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-            skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+            failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+            errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+            skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.ta-version-from-upgrade }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else
@@ -2879,9 +2879,9 @@ jobs:
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
               total_tests=$(xmllint --xpath 'count(//testcase)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'count(//testcase[./failure])' "$junit_xml_file")
-              errors=$(xmllint --xpath 'count(//testcase[./error and not(./failure)])' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'count(//testcase[./skipped and not(./failure) and not(./error)])' "$junit_xml_file")
+              failures=$(xmllint --xpath 'count(//testcase[failure])' "$junit_xml_file")
+              errors=$(xmllint --xpath 'count(//testcase[error and not(failure)])' "$junit_xml_file")
+              skipped=$(xmllint --xpath 'count(//testcase[skipped and not(failure) and not(error)])' "$junit_xml_file")
               passed=$((total_tests - failures - errors - skipped))
               echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v3.5.1"
+        default: "v3.6.1"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"


### PR DESCRIPTION
### Description

Currently for test report if there are multiple blocks in the testcase tag (i.e error + failure) then it will count both and resulting summary may not align correctly. This PR updates the logic for report summary.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
o365: https://github.com/splunk/splunk-add-on-for-microsoft-office-365/actions/runs/16805102170?pr=858
