### PR TITLE
fix: Resolve discrepancies in test outcome counting

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -485,7 +485,7 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
             failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
             skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo -e "| Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests |\n| ----------- | ------------ | ------------ | ------------- | ------------- |\n| $total_tests | $passed | $failures | $errors | $skipped |" >> "$GITHUB_STEP_SUMMARY"
@@ -1342,7 +1342,7 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
             failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
             skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
@@ -1621,7 +1621,7 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
             failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
             skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
@@ -1898,7 +1898,7 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
             failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
             skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
@@ -2174,7 +2174,7 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
             failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
             skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.marker }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
@@ -2439,7 +2439,7 @@ jobs:
           if [ -n "$junit_xml_file" ]; then
             total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
             failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
-            errors=$(xmllint --xpath "count(//testcase[error])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
             skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
             passed=$((total_tests - failures - errors - skipped))
             echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ matrix.ta-version-from-upgrade }} ${{ matrix.vendor-version.image }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
@@ -2707,10 +2707,10 @@ jobs:
           junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
           junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
           if [ -n "$junit_xml_file" ]; then
-              total_tests=$(xmllint --xpath 'sum(//testsuite/@tests)' "$junit_xml_file")
-              failures=$(xmllint --xpath 'sum(//testsuite/@failures)' "$junit_xml_file")
-              errors=$(xmllint --xpath 'sum(//testsuite/@errors)' "$junit_xml_file")
-              skipped=$(xmllint --xpath 'sum(//testsuite/@skipped)' "$junit_xml_file")
+              total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+              failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+              errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+              skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
               passed=$((total_tests - failures - errors - skipped))
               echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }} |$total_tests |$passed |$failures |$errors |$skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
           else


### PR DESCRIPTION
### Description

Currently for test report if there are multiple blocks in the testcase tag (i.e error + failure) then it will count both and resulting summary may not align correctly. This PR updates the logic for report summary.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
o365:
https://github.com/splunk/splunk-add-on-for-microsoft-office-365/actions/runs/16805102170?pr=858

---------

### Description

(PR description goes here)

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
