### PR TITLE
feat: warn not to use centaurs

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -126,6 +126,18 @@ jobs:
             exit 1
           fi
 
+  check-splunktafunctionaltests-exists:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if grep -q 'splunktafunctionaltests' poetry.lock; then
+            echo "::warning title=\"splunktafunctionaltests\" should NOT be used for modinput tests::For more details, please see https://splunk.slack.com/archives/C081JT7R69Z/p1754662758743839."
+            exit 1
+          else
+            exit 0
+          fi
+
   check-docs-changes:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
### Description

Warn when `centaurs` is used.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 

* https://github.com/splunk/splunk-add-on-for-microsoft-office-365/actions/runs/17073350867/job/48408007804?pr=863
