### PR TITLE
feat: run UCC in an isolated virtual environment

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -479,14 +479,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Setup addon
         run: |
-          # DEBUG
-          set -x
-          
           if [ -f "poetry.lock" ]
           then
-            pwd
-            ls -lah
-          
             mkdir -p package/lib || true
             python${{ env.PYTHON_VERSION }} -m pip install poetry==${{ env.POETRY_VERSION }} poetry-plugin-export==${{ env.POETRY_EXPORT_PLUGIN_VERSION }}
             poetry check


### PR DESCRIPTION
### Description

[Document with more info](https://docs.google.com/document/d/1FqGxAY8onYWaTus0g5LbCQD9a8FGMn8-yIGMTLoea8k/edit?tab=t.0)

This PR allows to separate UCC from TA dependencies, in order to avoid dependency conflicts.

UCC version may be specified in requirements_ucc.txt file. Then, the action will install UCC in an isolated environment.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 

1. Build of a TA (no `requirements_ucc.txt` added): https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/17427842825/job/49479100399?pr=788
2. Build of a TA (`requirements_ucc.txt` added): https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/17426742577/job/49475535585?pr=788

