### PR TITLE
fix: Migrate GitHub Actions from PAT to GitHub App authentication

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -41,6 +41,12 @@ jobs:
       - pre-commit
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
         with:
           submodules: false
@@ -48,7 +54,7 @@ jobs:
       - name: Semantic Release
         uses: splunk/semantic-release-action@v1.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
@@ -60,10 +66,16 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
       - uses: splunk/addonfactory-update-semver@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -72,11 +72,10 @@ on:
         description: "Version of the GS scorecard"
         type: string
         default: "0.3"
-      gh-app-client-id:
-        required: true
-        description: "GitHub App Client ID for authentication"
-        type: string
     secrets:
+      GH_APP_CLIENT_ID:
+        description: GitHub App Client ID for authentication
+        required: true
       GH_APP_PRIVATE_KEY:
         description: GitHub App private key for authentication
         required: true
@@ -517,7 +516,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ inputs.gh-app-client-id }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
@@ -595,7 +594,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ inputs.gh-app-client-id }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
@@ -873,7 +872,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ inputs.gh-app-client-id }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
@@ -950,7 +949,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ inputs.gh-app-client-id }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
@@ -2974,7 +2973,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ inputs.gh-app-client-id }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Checkout

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -72,9 +72,13 @@ on:
         description: "Version of the GS scorecard"
         type: string
         default: "0.3"
+      gh-app-client-id:
+        required: true
+        description: "GitHub App Client ID for authentication"
+        type: string
     secrets:
-      GH_TOKEN_ADMIN:
-        description: Github admin token
+      GH_APP_PRIVATE_KEY:
+        description: GitHub App private key for authentication
         required: true
       SEMGREP_PUBLISH_TOKEN:
         description: Semgrep token
@@ -510,6 +514,12 @@ jobs:
       statuses: read
       checks: write
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ inputs.gh-app-client-id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -526,8 +536,8 @@ jobs:
             echo "No poetry.lock found, make sure your dependencies are managed through poetry, exiting"
             exit 1
           fi
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
           python${{ env.PYTHON_VERSION }} -m venv ~/.dev_venv
           ~/.dev_venv/bin/python${{ env.PYTHON_VERSION }} -m pip install -r package/lib/requirements.txt
       - name: Create directories
@@ -582,6 +592,12 @@ jobs:
       contents: write
       packages: read
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ inputs.gh-app-client-id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
         with:
           # Very Important semantic-release won't trigger a tagged
@@ -593,8 +609,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: create requirements file for pip
         run: |
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
@@ -854,6 +870,12 @@ jobs:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.setup-workflow.outputs.execute-gs-scorecard == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ inputs.gh-app-client-id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -868,7 +890,7 @@ jobs:
           docker pull 956110764581.dkr.ecr.us-west-2.amazonaws.com/ta-automation/gs-scorecard:${{ env.GS_IMAGE_VERSION }}
       - name: Run GS Scorecard
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_USERNAME: ${{ secrets.SA_GH_USER_NAME }}
           APPINSPECT_USER: ${{ secrets.SPL_COM_USER }}
           APPINSPECT_PASS: ${{ secrets.SPL_COM_PASSWORD }}
@@ -925,10 +947,16 @@ jobs:
     env:
       BUILD_NAME: ${{ needs.build.outputs.buildname }}
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ inputs.gh-app-client-id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.GH_TOKEN_ADMIN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: setup for test
         id: test-setup
         shell: bash
@@ -980,9 +1008,9 @@ jobs:
           python${{ env.PYTHON_VERSION }} -m pip install poetry==${{ env.POETRY_VERSION }}
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
-          export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ secrets.GH_TOKEN_ADMIN }}
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
+          export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ steps.app-token.outputs.token }}
+          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
       - name: modinput-test-prerequisites
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash
@@ -2943,6 +2971,12 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ inputs.gh-app-client-id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -2953,7 +2987,7 @@ jobs:
         id: semantic
         uses: splunk/semantic-release-action@v1.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
@@ -2964,7 +2998,7 @@ jobs:
         id: custom
         uses: "softprops/action-gh-release@v2"
         with:
-          token: "${{ secrets.GH_TOKEN_ADMIN }}"
+          token: "${{ steps.app-token.outputs.token }}"
           tag_name: v${{ github.event.inputs.custom-version }}
           target_commitish: "${{github.ref_name}}"
           make_latest: false

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -66,7 +66,7 @@ on:
         required: false
         description: "Version of the GS scorecard Docker image"
         type: string
-        default: "1.0.0"
+        default: "1.1"
       gs-version:
         required: false
         description: "Version of the GS scorecard"
@@ -890,7 +890,14 @@ jobs:
         if: always()
         with:
           name: gs-scorecard-report
-          path: ./gs_scorecard.html
+          path: ./gs_scorecard.json
+
+      - name: Print GS Scorecard report
+        if: always()
+        run: |
+          echo "::group::GS Scorecard Report"
+          jq . ./gs_scorecard.json
+          echo "::endgroup::"
 
   setup:
     needs:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v4.0"
+        default: "v4.2"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ appinspect-api-html-report-self-service
 
 - Verify that the required secrets are properly configured in GitHub Actions:
   - `GSSA_AWS_ACCESS_KEY_ID` and `GSSA_AWS_SECRET_ACCESS_KEY` for AWS ECR access
-  - `GH_TOKEN_ADMIN` and `SA_GH_USER_NAME` for GitHub access
+  - `GH_APP_PRIVATE_KEY` (secret) and `GH_APP_CLIENT_ID` (variable) for GitHub App authentication, and `SA_GH_USER_NAME` for GitHub access
   - `SPL_COM_USER` and `SPL_COM_PASSWORD` for AppInspect integration
 
 - Check that the Docker image version specified in `GS_SCORECARD_VERSION` environment variable exists in the ECR registry.


### PR DESCRIPTION
### Description

Migrate GitHub Actions workflows from using a Personal Access Token (GH_TOKEN_ADMIN) to GitHub App authentication via actions/create-github-app-token@v3. GitHub App tokens are scoped, short-lived, and auditable, providing better security and traceability compared to long-lived Personal Access Tokens.


### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/24390045573
