### PR TITLE
fix: bump gssa version

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -66,7 +66,7 @@ on:
         required: false
         description: "Version of the GS scorecard Docker image"
         type: string
-        default: "1.1"
+        default: "1.2"
       gs-version:
         required: false
         description: "Version of the GS scorecard"


### PR DESCRIPTION
### Description

Update the GSSA image version to 1.2 to replace the deprecated Claude 3.6.
The new GSSA image now uses Claude 4.6 by defualt.

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/25112929634/job/73592285875?pr=853
