### PR TITLE
fix: use x-access-token user for GitHub App token in git insteadOf

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -558,8 +558,8 @@ jobs:
             echo "No poetry.lock found, make sure your dependencies are managed through poetry, exiting"
             exit 1
           fi
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
           python${{ env.PYTHON_VERSION }} -m venv ~/.dev_venv
           ~/.dev_venv/bin/python${{ env.PYTHON_VERSION }} -m pip install -r package/lib/requirements.txt
       - name: Create directories
@@ -635,8 +635,8 @@ jobs:
           java-version: '17'
       - name: create requirements file for pip
         run: |
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
@@ -1040,8 +1040,8 @@ jobs:
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ steps.app-token.outputs.token }}
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
       - name: modinput-test-prerequisites
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash


### PR DESCRIPTION
## Summary

The PAT → GitHub App migration in #484 rewrites private-repo clones via:

```
git config --global --add url."https://${TOKEN}@github.com".insteadOf https://github.com
git config --global --add url."https://${TOKEN}@github.com".insteadOf ssh://git@github.com
```

That worked for PATs (GitHub accepts a PAT as the *username*), but **GitHub App installation tokens require the literal username `x-access-token`**. With only `<TOKEN>@github.com`, git treats the token as the username, GitHub returns 401, and git falls back to a non-interactive password prompt:

```
fatal: could not read Password for 'https://***@github.com': No such device or address
exit code: 128
```

This is currently breaking downstream add-ons that install private \`git+ssh\` dependencies (e.g. \`splunk/psa-cim-models\`) during the reusable workflow's \`run-unit-tests\` step. Example failing run: <https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/27150540186/job/80206858148>.

## Fix

Prefix the rewritten URL with \`x-access-token:\` in all three jobs that perform the rewrite:

- \`run-unit-tests\`
- \`build\`
- \`run-ucc-modinput-functional-tests\` (setup-poetry)

```diff
- git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
- git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+ git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+ git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
```

Targeting \`main\` so it can ship as a \`v5.5.x\` patch (matches the path taken by #495/#496/#497/#500).

## Note on App scope (not part of this PR)

Even with this fix, the GitHub App identified by \`GH_APP_CLIENT_ID\` / \`GH_APP_PRIVATE_KEY\` must be installed on the private dependency repo (e.g. \`splunk/psa-cim-models\`) with \`contents: read\`. Otherwise the clone will now fail with a clearer 403/404 instead of the password-prompt error. The \`create-github-app-token\` call only specifies \`owner: \${{ github.repository_owner }}\`, so it inherits whatever repos the App is installed on in the org.

## Checklist

- [ ] \`README.md\` has been updated or is not required
- [x] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [x] workflow errors/warnings reviewed and addressed

## Testing done

To verify after merge & v5.5.x tag: re-run the failing \`splunk-add-on-for-microsoft-cloud-services\` pipeline pinned to the new tag and confirm \`run-unit-tests\` clones \`splunk/psa-cim-models\` successfully.

Made with [Cursor](https://cursor.com)