### PR TITLE
chore: sync develop to main

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -599,6 +599,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: create requirements file for pip
         run: |
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -558,8 +558,8 @@ jobs:
             echo "No poetry.lock found, make sure your dependencies are managed through poetry, exiting"
             exit 1
           fi
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
           python${{ env.PYTHON_VERSION }} -m venv ~/.dev_venv
           ~/.dev_venv/bin/python${{ env.PYTHON_VERSION }} -m pip install -r package/lib/requirements.txt
       - name: Create directories
@@ -635,8 +635,8 @@ jobs:
           java-version: '17'
       - name: create requirements file for pip
         run: |
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
           if [ -f "poetry.lock" ]
           then
             echo " poetry.lock found "
@@ -1040,8 +1040,8 @@ jobs:
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ steps.app-token.outputs.token }}
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
-          git config --global --add url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
       - name: modinput-test-prerequisites
         if: steps.download-openapi.conclusion != 'skipped'
         shell: bash

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -62,6 +62,11 @@ on:
         description: "Python version to use for testing"
         type: string
         default: "3.9"
+      spl2-generate:
+        required: false
+        description: "Run spl2-generate hook during pre-commit step"
+        type: boolean
+        default: false
       gs-image-version:
         required: false
         description: "Version of the GS scorecard Docker image"
@@ -461,7 +466,7 @@ jobs:
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
 
-  lint:
+  pre-commit:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -472,7 +477,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit (skip spl2-generate)
+        if: ${{ !inputs['spl2-generate'] }}
+        uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: spl2-generate
+      - name: Run pre-commit (with spl2-generate)
+        if: ${{ inputs['spl2-generate'] }}
+        uses: pre-commit/action@v3.0.1
 
   review_secrets:
     name: security-detect-secrets
@@ -578,7 +590,7 @@ jobs:
       - setup-workflow
       - meta
       - compliance-copyrights
-      - lint
+      - pre-commit
       - review_secrets
       - semgrep
       - run-unit-tests
@@ -2903,6 +2915,258 @@ jobs:
         with:
           name: |
             summary-scripted*
+  run-spl2-integration-tests:
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.setup-workflow.outputs.execute-spl2 == 'true' }}
+    needs:
+      - build
+      - setup
+      - meta
+      - setup-workflow
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_latestSplunk) }}
+        spl2-test-type: [ "CIM", "TA" ]
+    container:
+      image: ghcr.io/splunk/workflow-engine-base:4.1.0
+    env:
+      ARGO_SERVER: ${{ needs.setup.outputs.argo-server }}
+      ARGO_HTTP1: ${{ needs.setup.outputs.argo-http1 }}
+      ARGO_SECURE: ${{ needs.setup.outputs.argo-secure }}
+      ARGO_BASE_HREF: ${{ needs.setup.outputs.argo-href }}
+      ARGO_NAMESPACE: ${{ needs.setup.outputs.argo-namespace }}
+      SPLUNK_VERSION_BASE: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
+      TEST_TYPE: "spl2_integration_tests"
+      TEST_ARGS: ""
+      SPL2_TEST_TYPE: ${{ matrix.spl2-test-type }}
+    permissions:
+      actions: read
+      deployments: read
+      contents: read
+      packages: read
+      statuses: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: configure git  # This step configures git to omit "dubious git ownership error" in later test-reporter stage
+        id: configure-git
+        run: |
+          git --version
+          git_path="$(pwd)"
+          echo "$git_path"
+          git config --global --add safe.directory "$git_path"
+      - name: capture start time
+        id: capture-start-time
+        run: |
+          echo "start_time=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        id: get-argo-token
+        run: |
+          ARGO_TOKEN=$(aws secretsmanager get-secret-value --secret-id "${{ needs.setup-workflow.outputs.argo_token_secret_id_k8s }}" | jq -r '.SecretString')
+          echo "argo-token=$ARGO_TOKEN" >> "$GITHUB_OUTPUT"
+      - name: create job name
+        id: create-job-name
+        shell: bash
+        run: |
+          RANDOM_STRING=$(head -3 /dev/urandom | tr -cd '[:lower:]' | cut -c -4)
+          JOB_NAME=${{ needs.setup.outputs.job-name }}-${RANDOM_STRING}
+          JOB_NAME=${JOB_NAME//TEST-TYPE/${{ env.TEST_TYPE }}}
+          JOB_NAME=${JOB_NAME}-${{ env.SPL2_TEST_TYPE }}
+          JOB_NAME=${JOB_NAME//[_.]/-}
+          JOB_NAME=$(echo "$JOB_NAME" | tr '[:upper:]' '[:lower:]')
+          echo "job-name=$JOB_NAME" >> "$GITHUB_OUTPUT"
+      - name: run-tests
+        id: run-tests
+        timeout-minutes: 340
+        continue-on-error: true
+        env:
+          ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
+        uses: splunk/wfe-test-runner-action@v5.2
+        with:
+          splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
+          test-type: ${{ env.TEST_TYPE }}
+          test-args: ${{ env.TEST_ARGS }} ${{ env.SPL2_TEST_TYPE }}
+          job-name: ${{ steps.create-job-name.outputs.job-name }}
+          labels: ${{ needs.setup.outputs.labels }}
+          workflow-tmpl-name: ${{ needs.setup.outputs.argo-workflow-tmpl-name }}
+          workflow-template-ns: ${{ needs.setup.outputs.argo-namespace }}
+          addon-url: ${{ needs.setup.outputs.addon-upload-path }}
+          addon-name: ${{ needs.setup.outputs.addon-name }}
+          vendor-version: ${{ matrix.vendor-version.image }}
+          sc4s-version: "No"
+          k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
+        id: update-argo-token
+        if: ${{ !cancelled() }}
+        run: |
+          ARGO_TOKEN=$(aws secretsmanager get-secret-value --secret-id "${{ needs.setup-workflow.outputs.argo_token_secret_id_k8s }}" | jq -r '.SecretString')
+          echo "argo-token=$ARGO_TOKEN" >> "$GITHUB_OUTPUT"
+      - name: calculate timeout
+        id: calculate-timeout
+        run: |
+          start_time=${{ steps.capture-start-time.outputs.start_time }}
+          current_time=$(date +%s)
+          remaining_time_minutes=$(( 300-((current_time-start_time)/60) ))
+          echo "remaining_time_minutes=$remaining_time_minutes" >> "$GITHUB_OUTPUT"
+      - name: Check if pod was deleted
+        id: is-pod-deleted
+        timeout-minutes: ${{ fromJson(steps.calculate-timeout.outputs.remaining_time_minutes) }}
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          ARGO_TOKEN: ${{ steps.update-argo-token.outputs.argo-token }}
+        run: |
+          set -o xtrace
+          if argo watch ${{ steps.run-tests.outputs.workflow-name }} -n workflows | grep "pod deleted"; then
+            echo "retry-workflow=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Cancel workflow
+        env:
+          ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
+        if: ${{ cancelled() || steps.is-pod-deleted.outcome != 'success' }}
+        run: |
+          cancel_response=$(argo submit -v -o json --from wftmpl/${{ needs.setup.outputs.argo-cancel-workflow-tmpl-name }} -l workflows.argoproj.io/workflow-template=${{ needs.setup.outputs.argo-cancel-workflow-tmpl-name }} --argo-base-href '' -p workflow-to-cancel=${{ steps.run-tests.outputs.workflow-name }})
+          cancel_workflow_name=$( echo "$cancel_response" |jq -r '.metadata.name' )
+          cancel_logs=$(argo logs --follow "$cancel_workflow_name" -n workflows)
+          if echo "$cancel_logs" | grep -q "workflow ${{ steps.run-tests.outputs.workflow-name }} stopped"; then
+            echo "Workflow ${{ steps.run-tests.outputs.workflow-name }} stopped"
+          else
+            echo "Workflow ${{ steps.run-tests.outputs.workflow-name }} didn't stop"
+            exit 1
+          fi
+      - name: Retrying workflow
+        id: retry-wf
+        shell: bash
+        env:
+          ARGO_TOKEN: ${{ steps.update-argo-token.outputs.argo-token }}
+        if: ${{ !cancelled() }}
+        run: |
+          set -o xtrace
+          set +e
+          if [[ "${{ steps.is-pod-deleted.outputs.retry-workflow }}" == "true" ]]
+          then
+            WORKFLOW_NAME=$(argo resubmit -v -o json -n workflows "${{ steps.run-tests.outputs.workflow-name }}" | jq -r .metadata.name)
+            echo "workflow-name=$WORKFLOW_NAME" >> "$GITHUB_OUTPUT"
+            argo logs --follow "${WORKFLOW_NAME}" -n workflows || echo "... there was an error fetching logs, the workflow is still in progress. please wait for the workflow to complete ..."
+          else
+            echo "No retry required"
+            argo wait "${{ steps.run-tests.outputs.workflow-name }}" -n workflows
+            argo watch "${{ steps.run-tests.outputs.workflow-name }}" -n workflows | grep "test-addon"
+          fi
+      - name: check if workflow completed
+        env:
+          ARGO_TOKEN: ${{ steps.update-argo-token.outputs.argo-token }}
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set +e
+          # shellcheck disable=SC2157
+          if [ -z "${{ steps.retry-wf.outputs.workflow-name }}" ]; then
+            WORKFLOW_NAME=${{ steps.run-tests.outputs.workflow-name }}
+          else
+            WORKFLOW_NAME="${{ steps.retry-wf.outputs.workflow-name }}"
+          fi
+          ARGO_STATUS=$(argo get "${WORKFLOW_NAME}" -n workflows -o json | jq -r '.status.phase')
+          echo "Status of workflow:" "$ARGO_STATUS"
+          while [ "$ARGO_STATUS" == "Running"  ] || [ "$ARGO_STATUS" == "Pending" ]
+          do
+              echo "... argo Workflow ${WORKFLOW_NAME} is running, waiting for it to complete."
+              argo wait "${WORKFLOW_NAME}" -n workflows || true
+              ARGO_STATUS=$(argo get "${WORKFLOW_NAME}" -n workflows -o json | jq -r '.status.phase')
+          done
+      - name: pull artifacts from s3 bucket
+        if: ${{ !cancelled() }}
+        run: |
+          echo "pulling artifacts"
+          aws s3 cp s3://${{ needs.setup.outputs.s3-bucket }}/artifacts-${{ steps.create-job-name.outputs.job-name }}/${{ steps.create-job-name.outputs.job-name }}.tgz ${{ needs.setup.outputs.directory-path }}/
+          tar -xf ${{ needs.setup.outputs.directory-path }}/${{ steps.create-job-name.outputs.job-name }}.tgz -C ${{ needs.setup.outputs.directory-path }}
+      - name: pull logs from s3 bucket
+        if: ${{ !cancelled() }}
+        run: |
+          # shellcheck disable=SC2157
+          if [ -z "${{ steps.retry-wf.outputs.workflow-name }}" ]; then
+            WORKFLOW_NAME=${{ steps.run-tests.outputs.workflow-name }}
+          else
+            WORKFLOW_NAME="${{ steps.retry-wf.outputs.workflow-name }}"
+          fi
+          echo "pulling logs"
+          mkdir -p ${{ needs.setup.outputs.directory-path }}/argo-logs
+          aws s3 cp s3://${{ needs.setup.outputs.s3-bucket }}/${WORKFLOW_NAME}/ ${{ needs.setup.outputs.directory-path }}/argo-logs/ --recursive
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ env.SPL2_TEST_TYPE }} tests artifacts
+          path: |
+            ${{ needs.setup.outputs.directory-path }}/test-results
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ env.SPL2_TEST_TYPE }} tests logs
+          path: |
+            ${{ needs.setup.outputs.directory-path }}/argo-logs
+      - name: Test Report
+        id: test_report
+        uses: dorny/test-reporter@v1.9.1
+        if: ${{ !cancelled() }}
+        with:
+          name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ env.SPL2_TEST_TYPE }} test report
+          path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
+          reporter: java-junit
+      - name: Parse JUnit XML
+        if: ${{ !cancelled() }}
+        run: |
+          apt-get update
+          apt-get install -y libxml2-utils
+          junit_xml_path="${{ needs.setup.outputs.directory-path }}/test-results"
+          junit_xml_file=$(find "$junit_xml_path" -name "*.xml" -type f 2>/dev/null | head -n 1)
+          if [ -n "$junit_xml_file" ]; then
+            total_tests=$(xmllint --xpath "count(//testcase)" "$junit_xml_file")
+            failures=$(xmllint --xpath "count(//testcase[failure])" "$junit_xml_file")
+            errors=$(xmllint --xpath "count(//testcase[error and not(failure)])" "$junit_xml_file")
+            skipped=$(xmllint --xpath "count(//testcase[skipped])" "$junit_xml_file")
+            passed=$((total_tests - failures - errors - skipped))
+            echo "splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.SPL2_TEST_TYPE }} |$total_tests |$passed |$failures |$errors | $skipped |${{steps.test_report.outputs.url_html}}" > job_summary.txt
+          else
+            echo "no XML File found, exiting"
+            exit 1
+          fi
+      - name: Upload-artifact-for-github-summary
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: summary-${{ env.TEST_TYPE }}-${{ matrix.splunk.version }}-${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}-${{ env.SPL2_TEST_TYPE }}-artifact
+          path: job_summary.txt
+
+  spl2-integration-tests-report:
+    needs: run-spl2-integration-tests
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.run-spl2-integration-tests.result != 'skipped' }}
+    steps:
+      - name: Download all summaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: summary-spl2_integration_tests*
+      - name: Combine summaries into a table
+        run: |
+          echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
+          for file in summary-spl2_integration_tests*/job_summary.txt; do
+            cat "$file" >> "$GITHUB_STEP_SUMMARY"
+          done
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            summary-spl2_integration_tests*
 
   pre-publish:
     if: ${{ !cancelled() }}
@@ -2917,7 +3181,7 @@ jobs:
       - validate-custom-version
       - meta
       - compliance-copyrights
-      - lint
+      - pre-commit
       - review_secrets
       - semgrep
       - build

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1275,7 +1275,7 @@ jobs:
       - name: Run spl2 tests
         run: |
           echo "Running SPL2 Tests"
-          spl2_tests_run cli -n 8 -o log_cli=true --log-cli-level=INFO --verbose --junitxml test-results/report.xml
+          spl2_tests_run cli -n 8 --ignore_additional_fields_in_actual --ignore_empty_strings -o log_cli=true --log-cli-level=INFO --verbose --junitxml test-results/report.xml
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1.9.1

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -45,7 +45,7 @@ on:
         description: "list of OS used for scripted input tests"
         type: string
         default: >-
-          ["ubuntu:16.04", "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "redhat:8.4", "redhat:8.5", "redhat:8.6", "redhat:8.8", "redhat:9.5"]
+          ["ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "redhat:8.4", "redhat:8.5", "redhat:8.6", "redhat:8.8", "redhat:9.5"]
       upgrade-tests-ta-versions:
         required: false
         description: "List with TA versions (in 'X.X.X' format) that should be used as starting points for upgrade tests. Example: ['7.6.0', '7.7.0']"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1275,7 +1275,7 @@ jobs:
       - name: Run spl2 tests
         run: |
           echo "Running SPL2 Tests"
-          spl2_tests_run cli -o log_cli=true --log-cli-level=INFO --verbose --junitxml test-results/report.xml
+          spl2_tests_run cli -n 8 -o log_cli=true --log-cli-level=INFO --verbose --junitxml test-results/report.xml
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v1.9.1

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -78,6 +78,9 @@ on:
         type: string
         default: "0.3"
     secrets:
+      GH_TOKEN_ADMIN:
+        description: Github admin token
+        required: true
       GH_APP_CLIENT_ID:
         description: GitHub App Client ID for authentication
         required: true

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -3266,12 +3266,6 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
-      - uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -3282,7 +3276,7 @@ jobs:
         id: semantic
         uses: splunk/semantic-release-action@v1.3
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
@@ -3293,7 +3287,7 @@ jobs:
         id: custom
         uses: "softprops/action-gh-release@v2"
         with:
-          token: "${{ steps.app-token.outputs.token }}"
+          token: "${{ secrets.GH_TOKEN_ADMIN }}"
           tag_name: v${{ github.event.inputs.custom-version }}
           target_commitish: "${{github.ref_name}}"
           make_latest: false

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v4.0"
+        default: "v4.2"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -971,7 +971,7 @@ jobs:
           then
               ADDON_NAME=$(echo "${ADDON_NAME}" | awk -F '_FOR_SPLUNK' '{print $1}')
           fi
-          JOB_NAME=$(echo "$ADDON_NAME" | tail -c 16)-$(echo "${GITHUB_SHA}" | tail -c 8)-TEST-TYPE-${GITHUB_RUN_ID}
+          JOB_NAME=$(echo "$ADDON_NAME" | tail -c 8)-$(echo "${GITHUB_SHA}" | tail -c 8)-TEST-TYPE-${GITHUB_RUN_ID}
           JOB_NAME=${JOB_NAME//[_.]/-}
           LABELS="addon-name=${ADDON_NAME}"
           ADDON_UPLOAD_PATH="s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/${{ needs.build.outputs.buildname }}"
@@ -2979,8 +2979,7 @@ jobs:
         run: |
           RANDOM_STRING=$(head -3 /dev/urandom | tr -cd '[:lower:]' | cut -c -4)
           JOB_NAME=${{ needs.setup.outputs.job-name }}-${RANDOM_STRING}
-          JOB_NAME=${JOB_NAME//TEST-TYPE/${{ env.TEST_TYPE }}}
-          JOB_NAME=${JOB_NAME}-${{ env.SPL2_TEST_TYPE }}
+          JOB_NAME=${JOB_NAME//TEST-TYPE/spl2-inte}
           JOB_NAME=${JOB_NAME//[_.]/-}
           JOB_NAME=$(echo "$JOB_NAME" | tr '[:upper:]' '[:lower:]')
           echo "job-name=$JOB_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -66,7 +66,7 @@ on:
         required: false
         description: "Version of the GS scorecard Docker image"
         type: string
-        default: "1.1"
+        default: "1.2"
       gs-version:
         required: false
         description: "Version of the GS scorecard"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   * [[Job] run-ui-tests](#job-run-ui-tests-)
   * [[Job] run-modinput-tests](#job-run-modinput-tests-)
   * [[Job] run-ucc-modinput-tests](#job-run-ucc-modinput-tests-)
+  * [[Job] run-spl2-integration-tests](#job-run-spl2-integration-tests)
   * [[Job] run-upgrade-tests](#job-run-upgrade-tests)
   * [[Job] run-scripted-input-tests-full-matrix](#job-run-scripted-input-tests-full-matrix)
   * [[Job] pre-publish](#job-pre-publish)
@@ -872,6 +873,60 @@ splunk-add-on-ucc-modinput-test-functional.log
 Junit XML file
 ```
 
+## [Job] run-spl2-integration-tests
+
+**Description**
+
+- This job runs SPL2 integration tests against a real Splunk instance to validate that the add-on's data is correctly ingested and searchable using the SPL2 query language.
+- Tests are executed using the `spl2-testing-framework` and `conf-spl2-converter` tools.
+- The job runs as a matrix: for each latest Splunk version, two parallel jobs are created — one for **CIM** checks and one for **TA** checks — controlled by the `spl2-test-type` matrix parameter (`CIM` or `TA`).
+- Triggered only when `execute-spl2` flag is set to `true` by the `setup-workflow` job.
+
+**Action used:**
+- [`splunk/wfe-test-runner-action`](https://github.com/splunk/wfe-test-runner-action) — submits and monitors the Argo workflow
+- Custom Docker image: `workflow-engine/workflow-engine-ta-test-spl2-base`
+- `spl2-testing-framework` — Python package for running SPL2 tests
+- `conf-spl2-converter` — converts conf files to SPL2 expected format
+
+**Matrix:**
+
+| Parameter | Values |
+|---|---|
+| `splunk` | latest Splunk version from `meta` job |
+| `spl2-test-type` | `CIM`, `TA` |
+
+**Test types:**
+
+- `CIM` — validates that data is correctly mapped to CIM data models (`--check_splunk_results=CIM`)
+- `TA` — validates TA-specific search results (`--check_splunk_results=TA`)
+
+**Pass/fail behaviour:**
+
+- The job fails if `spl2_tests_run` returns a non-zero exit code for the selected test type.
+- Each matrix job (CIM / TA) runs independently and reports separately.
+
+**Enabling for an add-on:**
+
+- The job is enabled when `setup-workflow` outputs `execute-spl2: true`.
+- To enable it, ensure the `execute_spl2` flag is configured in your `build-test-release.yml`.
+
+**Troubleshooting steps for failures if any:**
+
+- Check the Argo workflow logs for detailed output from `spl2_tests_run`.
+- Verify Splunk instance connectivity: `SPL2_TF_SPLUNK_INSTANCE_IP` must point to a reachable host.
+- Confirm `spl2-testing-framework` version is compatible (currently pinned to `1.6.0`).
+- Pull test artifacts from S3 for full logs and XML report.
+- For CIM failures: validate that sourcetypes are correctly tagged in the add-on's `tags.conf`.
+- For TA failures: verify expected search results match actual ingested data.
+
+**Artifacts:**
+
+```
+report-spl2-cim-results.xml   (for CIM job)
+report-spl2-ta-results.xml    (for TA job)
+```
+
+
 ## [Job] run-upgrade-tests
 
 **Description:**
@@ -924,6 +979,7 @@ argo-logs
 Junit XML file
 argo-logs
 ```
+
 
 
 ## [Job] pre-publish


### PR DESCRIPTION
## Summary

- Fast-forwards `develop` to match `main` (tip: `36d2c0f`)
- Brings in 20 commits that landed on `main` since last sync (#492), including fixes for PAT/GitHub App auth, spl2 tests, ubuntu 16.04 EOL drop, and manifests pin
- No unique commits on `develop` that are missing from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)