### PR TITLE
fix: make GS Scorecard non-blocking for releases (backport)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -934,19 +934,18 @@ jobs:
         with:
           name: gs-scorecard-report
           path: ./gs_scorecard.json
-      - name: Print and verify GS Scorecard report
+      - name: Print GS Scorecard report
         run: |
           if [ ! -f ./gs_scorecard.json ]; then
-            echo "::error::GS Scorecard report not found"
-            exit 1
+            echo "::warning::GS Scorecard report not found"
+            exit 0
           fi
           echo "::group::GS Scorecard Report"
           jq . ./gs_scorecard.json
           echo "::endgroup::"
           passed=$(jq -r '.result.passed' ./gs_scorecard.json)
           if [ "$passed" != "true" ]; then
-            echo "::error::GS Scorecard failed"
-            exit 1
+            echo "::warning::GS Scorecard did not pass - this is informational only and will not block the release"
           fi
 
   setup:
@@ -3229,18 +3228,7 @@ jobs:
         id: check
         shell: bash
         run: |
-          # GS Scorecard: must have run for PRs to main (result doesn't matter, but skipped = blocked)
-          GS_RESULT=$(echo "$NEEDS" | jq -r '.["run-gs-scorecard"].result')
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.base_ref }}" == "main" ]] && [[ "$GS_RESULT" == "skipped" ]] && [[ "${{ needs.check-docs-changes.outputs.docs-only }}" != "true" ]]; then
-            echo "::error::GS Scorecard is required for merging PRs to main. To unblock merging please add the 'execute_gs_scorecard' label and re-run the workflow."
-            echo "## GS Scorecard Required" >> "$GITHUB_STEP_SUMMARY"
-            echo "Add the \`execute_gs_scorecard\` label to this PR and re-run the workflow. GS Scorecard must complete before merging to main (result does not need to pass)." >> "$GITHUB_STEP_SUMMARY"
-            echo "run-publish=false" >> "$GITHUB_OUTPUT"
-            echo "Publish conditions are not met."
-            exit 1
-          fi
-
-          # Exclude run-gs-scorecard from the general check since it has its own handling above
+          # GS Scorecard: informational only, never blocks release
           RUN_PUBLISH=$(echo "$NEEDS" | jq 'del(.["run-gs-scorecard"]) | .[] | select((.result != "skipped") and .result != "success") | length == 0')
           if [[ "$RUN_PUBLISH" != *'false'* ]] && [[ "${{ needs.check-docs-changes.outputs.docs-only }}" == 'false' ]]
           then


### PR DESCRIPTION
## Summary

Backport of #505 to `develop`.

- GS Scorecard tool remains available via `execute_gs_scorecard` label
- Scorecard results are now informational warnings only, never blocking releases
- Removes the `pre-publish` gate that blocked releases when scorecard was skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)