### PR TITLE
feat: run modinput tests with python.version variants for Splunk 9.4

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -34,12 +34,12 @@ on:
         required: false
         description: Specifies which environment to use for k8s testing. ["production", "staging"]
         type: string
-        default: "staging"
+        default: "production"
       k8s-manifests-branch:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "feat/splunk-9-4-python-version"
+        default: "v4.2"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"
@@ -378,6 +378,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix_Splunk: ${{ steps.determine_splunk.outputs.matrixSplunk }}
+      matrix_splunkModinput: ${{ steps.determine_splunk.outputs.matrixSplunkModinput }}
       matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
       matrix_latestSplunk: ${{ steps.matrix.outputs.latestSplunk }}
       matrix_supportedSC4S: ${{ steps.matrix.outputs.supportedSC4S }}
@@ -412,8 +413,10 @@ jobs:
           fi
           if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
             echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunkModinput=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
           else
             echo "matrixSplunk=${{ toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunkModinput=${{ toJson(steps.matrix.outputs.supportedSplunkModinput) }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: job summary
@@ -1160,7 +1163,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1404,7 +1407,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1690,7 +1693,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           test-browser: ${{ env.TEST_BROWSER }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1876,7 +1879,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkModinput) }}
         modinput-type: [ "modinput_functional" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         marker: ${{ fromJson(inputs.marker) }}
@@ -2153,7 +2156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkModinput) }}
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         marker: ${{ fromJson(inputs.ucc-modinput-marker) }}
     container:
@@ -2508,7 +2511,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           ta-upgrade-version: ${{ matrix.ta-version-from-upgrade }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2784,7 +2787,7 @@ jobs:
           os-version: ${{ steps.os-name-version.outputs.os-version }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: calculate timeout
         id: calculate-timeout
         run: |
@@ -3041,7 +3044,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "feat/splunk-9-4-python-version"
+        default: "v4.2"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"
@@ -393,7 +393,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@feat/splunk-9-4-python-version
+        uses: splunk/addonfactory-test-matrix-action@v3.1
         with:
           features: PYTHON39
       - id: determine_splunk
@@ -412,12 +412,13 @@ jobs:
             fi
           fi
           if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
-            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
-            echo "matrixSplunkBase=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
+            MATRIX='${{ steps.matrix.outputs.latestSplunk }}'
           else
-            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
-            echo "matrixSplunkBase=${{ toJson(steps.matrix.outputs.supportedSplunkBase) }}" >> "$GITHUB_OUTPUT"
+            MATRIX='${{ steps.matrix.outputs.supportedSplunk }}'
           fi
+          echo "matrixSplunk=$MATRIX" >> "$GITHUB_OUTPUT"
+          MATRIX_BASE=$(echo "$MATRIX" | jq '[unique_by(.version) | .[] | del(.serverConfPythonVersion)]')
+          echo "matrixSplunkBase=$MATRIX_BASE" >> "$GITHUB_OUTPUT"
 
       - name: job summary
         run: |
@@ -1148,7 +1149,7 @@ jobs:
         timeout-minutes: 20
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1392,7 +1393,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1677,7 +1678,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1955,7 +1956,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2231,7 +2232,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2495,7 +2496,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2771,7 +2772,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -3029,7 +3030,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.2
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -34,12 +34,12 @@ on:
         required: false
         description: Specifies which environment to use for k8s testing. ["production", "staging"]
         type: string
-        default: "production"
+        default: "staging"
       k8s-manifests-branch:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v4.2"
+        default: "feat/splunk-9-4-python-version"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"
@@ -392,7 +392,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v3.1
+        uses: splunk/addonfactory-test-matrix-action@feat/splunk-9-4-python-version
         with:
           features: PYTHON39
       - id: determine_splunk
@@ -1145,7 +1145,7 @@ jobs:
         timeout-minutes: 20
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1160,6 +1160,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1388,7 +1389,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1403,6 +1404,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1672,7 +1674,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1688,6 +1690,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           test-browser: ${{ env.TEST_BROWSER }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1949,7 +1952,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1964,6 +1967,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2224,7 +2228,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2239,6 +2243,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2487,7 +2492,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2503,6 +2508,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           ta-upgrade-version: ${{ matrix.ta-version-from-upgrade }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2762,7 +2768,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2778,6 +2784,7 @@ jobs:
           os-version: ${{ steps.os-name-version.outputs.os-version }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: calculate timeout
         id: calculate-timeout
         run: |
@@ -3019,7 +3026,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -3034,6 +3041,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -34,7 +34,7 @@ on:
         required: false
         description: Specifies which environment to use for k8s testing. ["production", "staging"]
         type: string
-        default: "staging"
+        default: "production"
       k8s-manifests-branch:
         required: false
         description: "branch for k8s manifests to run the tests on"
@@ -412,13 +412,13 @@ jobs:
             fi
           fi
           if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
-            MATRIX='${{ steps.matrix.outputs.latestSplunk }}'
+            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunkBase=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
           else
-            MATRIX='${{ steps.matrix.outputs.supportedSplunk }}'
+            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
+            MATRIX_BASE=$(echo '${{ steps.matrix.outputs.supportedSplunk }}' | jq -c '[unique_by(.version) | .[] | del(.serverConfPythonVersion)]')
+            echo "matrixSplunkBase=$MATRIX_BASE" >> "$GITHUB_OUTPUT"
           fi
-          echo "matrixSplunk=$MATRIX" >> "$GITHUB_OUTPUT"
-          MATRIX_BASE=$(echo "$MATRIX" | jq '[unique_by(.version) | .[] | del(.serverConfPythonVersion)]')
-          echo "matrixSplunkBase=$MATRIX_BASE" >> "$GITHUB_OUTPUT"
 
       - name: job summary
         run: |

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -34,12 +34,12 @@ on:
         required: false
         description: Specifies which environment to use for k8s testing. ["production", "staging"]
         type: string
-        default: "production"
+        default: "staging"
       k8s-manifests-branch:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v4.2"
+        default: "feat/splunk-9-4-python-version"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"
@@ -378,7 +378,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix_Splunk: ${{ steps.determine_splunk.outputs.matrixSplunk }}
-      matrix_splunkBase: ${{ steps.determine_splunk.outputs.matrixSplunkBase }}
       matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
       matrix_latestSplunk: ${{ steps.matrix.outputs.latestSplunk }}
       matrix_supportedSC4S: ${{ steps.matrix.outputs.supportedSC4S }}
@@ -393,7 +392,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v3.1
+        uses: splunk/addonfactory-test-matrix-action@feat/splunk-9-4-python-version
         with:
           features: PYTHON39
       - id: determine_splunk
@@ -412,12 +411,9 @@ jobs:
             fi
           fi
           if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
-            echo "matrixSplunk=${{ steps.matrix.outputs.latestSplunk }}" >> "$GITHUB_OUTPUT"
-            echo "matrixSplunkBase=${{ steps.matrix.outputs.latestSplunk }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
           else
-            echo "matrixSplunk=${{ steps.matrix.outputs.supportedSplunk }}" >> "$GITHUB_OUTPUT"
-            MATRIX_BASE=$(echo '${{ steps.matrix.outputs.supportedSplunk }}' | jq -c '[unique_by(.version) | .[] | del(.serverConfPythonVersion)]')
-            echo "matrixSplunkBase=$MATRIX_BASE" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: job summary
@@ -1095,7 +1091,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0
@@ -1149,7 +1145,7 @@ jobs:
         timeout-minutes: 20
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1164,7 +1160,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ''
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1331,7 +1327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0
@@ -1393,7 +1389,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1408,7 +1404,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ''
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1601,7 +1597,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
         browser: [ "chrome" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
         marker: ${{ fromJson(inputs.ui_marker) }}
@@ -1678,7 +1674,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1694,7 +1690,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           test-browser: ${{ env.TEST_BROWSER }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ''
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1956,7 +1952,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2232,7 +2228,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2433,7 +2429,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         ta-version-from-upgrade: ${{ fromJson(inputs.upgrade-tests-ta-versions) }}
     container:
@@ -2496,7 +2492,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2512,7 +2508,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           ta-upgrade-version: ${{ matrix.ta-version-from-upgrade }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ''
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2698,7 +2694,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
         os: ${{ fromJson(inputs.scripted-inputs-os-list) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0
@@ -2772,7 +2768,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2788,7 +2784,7 @@ jobs:
           os-version: ${{ steps.os-name-version.outputs.os-version }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ''
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: calculate timeout
         id: calculate-timeout
         run: |
@@ -3030,7 +3026,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -3045,7 +3041,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ''
+          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1160,7 +1160,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1404,7 +1404,7 @@ jobs:
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -1690,7 +1690,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           test-browser: ${{ env.TEST_BROWSER }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2508,7 +2508,7 @@ jobs:
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           ta-upgrade-version: ${{ matrix.ta-version-from-upgrade }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}
@@ -2784,7 +2784,7 @@ jobs:
           os-version: ${{ steps.os-name-version.outputs.os-version }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: calculate timeout
         id: calculate-timeout
         run: |
@@ -3041,7 +3041,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           python-version: ${{ env.PYTHON_VERSION }}
-          server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
+          server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
         if: ${{ !cancelled() }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -378,6 +378,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix_Splunk: ${{ steps.determine_splunk.outputs.matrixSplunk }}
+      matrix_splunkBase: ${{ steps.determine_splunk.outputs.matrixSplunkBase }}
       matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
       matrix_latestSplunk: ${{ steps.matrix.outputs.latestSplunk }}
       matrix_supportedSC4S: ${{ steps.matrix.outputs.supportedSC4S }}
@@ -412,8 +413,10 @@ jobs:
           fi
           if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
             echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunkBase=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
           else
             echo "matrixSplunk=${{ toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunkBase=${{ toJson(steps.matrix.outputs.supportedSplunkBase) }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: job summary
@@ -1091,7 +1094,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0
@@ -1327,7 +1330,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
         sc4s: ${{ fromJson(needs.meta.outputs.matrix_supportedSC4S) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0
@@ -1597,7 +1600,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
         browser: [ "chrome" ]
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedUIVendors) }}
         marker: ${{ fromJson(inputs.ui_marker) }}
@@ -2429,7 +2432,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
         vendor-version: ${{ fromJson(needs.meta.outputs.matrix_supportedModinputFunctionalVendors) }}
         ta-version-from-upgrade: ${{ fromJson(inputs.upgrade-tests-ta-versions) }}
     container:
@@ -2694,7 +2697,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        splunk: ${{ fromJson(needs.meta.outputs.matrix_Splunk) }}
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_splunkBase) }}
         os: ${{ fromJson(inputs.scripted-inputs-os-list) }}
     container:
       image: ghcr.io/splunk/workflow-engine-base:4.1.0

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -412,10 +412,10 @@ jobs:
             fi
           fi
           if [[ "$wfe_run_on_splunk_latest" == "true" ]]; then
-            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
-            echo "matrixSplunkBase=${{ toJson(steps.matrix.outputs.latestSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunk=${{ steps.matrix.outputs.latestSplunk }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunkBase=${{ steps.matrix.outputs.latestSplunk }}" >> "$GITHUB_OUTPUT"
           else
-            echo "matrixSplunk=${{ toJson(steps.matrix.outputs.supportedSplunk) }}" >> "$GITHUB_OUTPUT"
+            echo "matrixSplunk=${{ steps.matrix.outputs.supportedSplunk }}" >> "$GITHUB_OUTPUT"
             MATRIX_BASE=$(echo '${{ steps.matrix.outputs.supportedSplunk }}' | jq -c '[unique_by(.version) | .[] | del(.serverConfPythonVersion)]')
             echo "matrixSplunkBase=$MATRIX_BASE" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -393,7 +393,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@feat/splunk-9-4-python-version
+        uses: splunk/addonfactory-test-matrix-action@v3.3
         with:
           features: PYTHON39
       - id: determine_splunk
@@ -1148,7 +1148,7 @@ jobs:
         timeout-minutes: 20
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1392,7 +1392,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1677,7 +1677,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1955,7 +1955,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2231,7 +2231,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2495,7 +2495,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2771,7 +2771,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -3029,7 +3029,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@feat/splunk-9-4-python-version
+        uses: splunk/wfe-test-runner-action@v5.3
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}


### PR DESCRIPTION
- `run-modinput-tests` and `run-ucc-modinput-tests` jobs use new `matrix_splunkModinput` output (from `addonfactory-test-matrix-action`) which contains two entries for Splunk 9.4: `serverConfPythonVersion: python3` and `serverConfPythonVersion: force_python3` — resulting in two separate test runs per modinput job
- All other test types (btool, knowledge, ui, upgrade, scripted inputs, spl2) use `matrix_Splunk` (standard output, no variants) — single run per Splunk version as before
- `server-conf-python-version` is passed to `wfe-test-runner-action` only for modinput and ucc-modinput jobs; all other jobs pass empty string
- Default values restored: `k8s-manifests-branch` → `v4.2`, `addonfactory-test-matrix-action` → `@v3.1`, `wfe-test-runner-action` → `@v5.2`

## Why

Splunk 9.4 requires explicit `python.version` configuration in `server.conf [general]`. Only modinput tests are affected — they execute scripted inputs whose Python version is controlled by this setting. Running two variants (`python3` and `force_python3`) ensures the add-on works under both configurations.

Other test types (btool, knowledge, UI) do not interact with the Python runtime selection and do not benefit from duplicate runs.

## Dependencies

Requires the following PRs to be merged and tagged first:
- `splunk/addonfactory-test-matrix-action` — provides `supportedSplunkModinput` output
- `splunk/wfe-test-runner-action` — provides `server-conf-python-version` input forwarding
- `splunk/ta-automation-k8s-manifests` — applies `python.version` in the Splunk pod

## Test plan

- [x] Verify PR to `main` triggers 2 modinput runs for Splunk 9.4 (`python3` and `force_python3`)
- [x] Verify all other test types have 1 run per Splunk version (no duplicate 9.4 runs)
- [x] Verify `btool server list general | grep python` returns correct value in each modinput run
- [x] Verify non-9.4 Splunk versions are unaffected

