### PR TITLE
feat: upload spl2 test results as artifact after execution

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1314,6 +1314,11 @@ jobs:
           name: spl2 test report
           path: "test-results/*.xml"
           reporter: java-junit
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: spl2 test results
+          path: test-results/
 
   run-knowledge-tests:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.setup-workflow.outputs.execute-knowledge == 'true' }}


### PR DESCRIPTION
## Summary

- Add `actions/upload-artifact@v4` step to `run-spl2-tests` job so test results are preserved as downloadable artifacts after each run
- Matches the artifact upload pattern already used in `run-knowledge-tests` and `run-unit-tests`
- Artifact named `spl2 test results`, contains the `test-results/` directory with JUnit XML output

## Test plan

- [ ] Verify CI runs `run-spl2-tests` and produces a downloadable `spl2 test results` artifact
- [ ] Confirm artifact contains `test-results/report.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)