### PR TITLE
fix: validate ADDON Jira ticket in PR title

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -129,6 +129,15 @@ on:
       GSSA_AWS_SECRET_ACCESS_KEY:
         description: GSSA AWS secret access key
         required: true
+      JIRA_BASE_URL:
+        description: Jira base URL, e.g. https://mycompany.atlassian.net
+        required: true
+      JIRA_USER_EMAIL:
+        description: Email of the Jira user used to post ticket comments
+        required: true
+      JIRA_API_TOKEN:
+        description: API token for the Jira user used to post ticket comments
+        required: true
 permissions:
   contents: read
   packages: read
@@ -381,6 +390,59 @@ jobs:
             echo "::error::PR title must contain a Jira ticket in the format ADDON-XXXXX (5-6 digits). Got: $PR_TITLE"
             exit 1
           fi
+
+  comment-on-jira:
+    name: Comment on Jira ticket
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Comment on referenced ADDON ticket(s)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMITS: ${{ toJson(github.event.commits) }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          SEEN=""
+          echo "$COMMITS" | jq -c '.[]' | while read -r commit; do
+            TITLE=$(jq -r '.message' <<<"$commit" | head -n1)
+            SHA=$(jq -r '.id' <<<"$commit")
+            if [[ ! "$TITLE" =~ (ADDON-[0-9]{5,6})([^0-9]|$) ]]; then
+              continue
+            fi
+            TICKET="${BASH_REMATCH[1]}"
+            if [[ " $SEEN " == *" $TICKET "* ]]; then
+              continue
+            fi
+            SEEN="$SEEN $TICKET"
+
+            COMMIT_URL="https://github.com/$REPO/commit/$SHA"
+            PR_URL=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].html_url // ""' || true)
+            BODY=$(jq -n \
+              --arg branch "$BRANCH" --arg repo "$REPO" \
+              --arg commit_url "$COMMIT_URL" --arg sha "${SHA:0:7}" --arg pr_url "$PR_URL" \
+              '{body: {type: "doc", version: 1, content: [{type: "paragraph", content: (
+                [{type: "text", text: ("Pushed to " + $branch + " in " + $repo + ": ")},
+                 {type: "text", text: $sha, marks: [{type: "link", attrs: {href: $commit_url}}]}]
+                + (if $pr_url != "" then
+                    [{type: "text", text: " (via "},
+                     {type: "text", text: "PR", marks: [{type: "link", attrs: {href: $pr_url}}]},
+                     {type: "text", text: ")"}]
+                  else [] end)
+              )}]}}')
+
+            echo "Commenting on $TICKET for commit ${SHA:0:7}"
+            curl --fail --silent --show-error \
+              -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              -X POST "$JIRA_BASE_URL/rest/api/3/issue/$TICKET/comment" \
+              -d "$BODY" || echo "::warning::Failed to comment on $TICKET for commit ${SHA:0:7}"
+          done
 
   meta:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -129,14 +129,11 @@ on:
       GSSA_AWS_SECRET_ACCESS_KEY:
         description: GSSA AWS secret access key
         required: true
-      JIRA_BASE_URL:
-        description: Jira base URL, e.g. https://mycompany.atlassian.net
+      ATLASSIAN_EMAIL:
+        description: Email of the Atlassian user used to post Jira ticket comments
         required: true
-      JIRA_USER_EMAIL:
-        description: Email of the Jira user used to post ticket comments
-        required: true
-      JIRA_API_TOKEN:
-        description: API token for the Jira user used to post ticket comments
+      ATLASSIAN_TOKEN:
+        description: API token for the Atlassian user used to post Jira ticket comments
         required: true
 permissions:
   contents: read
@@ -404,9 +401,9 @@ jobs:
           COMMITS: ${{ toJson(github.event.commits) }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_BASE_URL: https://splunk.atlassian.net
+          ATLASSIAN_EMAIL: ${{ secrets.ATLASSIAN_EMAIL }}
+          ATLASSIAN_TOKEN: ${{ secrets.ATLASSIAN_TOKEN }}
         run: |
           SEEN=""
           echo "$COMMITS" | jq -c '.[]' | while read -r commit; do
@@ -438,7 +435,7 @@ jobs:
 
             echo "Commenting on $TICKET for commit ${SHA:0:7}"
             curl --fail --silent --show-error \
-              -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+              -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN" \
               -H "Content-Type: application/json" \
               -X POST "$JIRA_BASE_URL/rest/api/3/issue/$TICKET/comment" \
               -d "$BODY" || echo "::warning::Failed to comment on $TICKET for commit ${SHA:0:7}"

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -394,6 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - name: Comment on referenced ADDON ticket(s)
         env:
@@ -419,7 +420,9 @@ jobs:
             SEEN="$SEEN $TICKET"
 
             COMMIT_URL="https://github.com/$REPO/commit/$SHA"
-            PR_URL=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].html_url // ""' || true)
+            if ! PR_URL=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].html_url // ""' 2>/dev/null); then
+              PR_URL=""
+            fi
             BODY=$(jq -n \
               --arg branch "$BRANCH" --arg repo "$REPO" \
               --arg commit_url "$COMMIT_URL" --arg sha "${SHA:0:7}" --arg pr_url "$PR_URL" \

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -410,6 +410,7 @@ jobs:
           echo "$COMMITS" | jq -c '.[]' | while read -r commit; do
             TITLE=$(jq -r '.message' <<<"$commit" | head -n1)
             SHA=$(jq -r '.id' <<<"$commit")
+            AUTHOR=$(jq -r '.author.username // .author.name' <<<"$commit")
             if [[ ! "$TITLE" =~ (ADDON-[0-9]{5,6})([^0-9]|$) ]]; then
               continue
             fi
@@ -424,17 +425,21 @@ jobs:
               PR_URL=""
             fi
             BODY=$(jq -n \
-              --arg branch "$BRANCH" --arg repo "$REPO" \
+              --arg author "$AUTHOR" --arg branch "$BRANCH" --arg repo "$REPO" \
               --arg commit_url "$COMMIT_URL" --arg sha "${SHA:0:7}" --arg pr_url "$PR_URL" \
-              '{body: {type: "doc", version: 1, content: [{type: "paragraph", content: (
-                [{type: "text", text: ("Pushed to " + $branch + " in " + $repo + ": ")},
-                 {type: "text", text: $sha, marks: [{type: "link", attrs: {href: $commit_url}}]}]
-                + (if $pr_url != "" then
-                    [{type: "text", text: " (via "},
-                     {type: "text", text: "PR", marks: [{type: "link", attrs: {href: $pr_url}}]},
-                     {type: "text", text: ")"}]
-                  else [] end)
-              )}]}}')
+              '{body: {type: "doc", version: 1, content: [
+                {type: "paragraph", content: [
+                  {type: "text", text: ($author + " mentioned this issue in a commit of " + $repo + " on branch " + $branch + ":")}
+                ]},
+                {type: "paragraph", content: (
+                  [{type: "text", text: $sha, marks: [{type: "link", attrs: {href: $commit_url}}]}]
+                  + (if $pr_url != "" then
+                      [{type: "text", text: " (via "},
+                       {type: "text", text: "PR", marks: [{type: "link", attrs: {href: $pr_url}}]},
+                       {type: "text", text: ")"}]
+                    else [] end)
+                )}
+              ]}}')
 
             echo "Commenting on $TICKET for commit ${SHA:0:7}"
             curl --fail --silent --show-error \

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -374,9 +374,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Validate ADDON Jira ticket in PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          if [[ ! "$PR_TITLE" =~ ADDON-[0-9]{5,6} ]]; then
+          if [[ ! "$PR_TITLE" =~ ADDON-[0-9]{5,6}([^0-9]|$) ]]; then
             echo "::error::PR title must contain a Jira ticket in the format ADDON-XXXXX (5-6 digits). Got: $PR_TITLE"
             exit 1
           fi

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -373,6 +373,13 @@ jobs:
           validateSingleCommit: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Validate ADDON Jira ticket in PR title
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if [[ ! "$PR_TITLE" =~ ADDON-[0-9]{5,6} ]]; then
+            echo "::error::PR title must contain a Jira ticket in the format ADDON-XXXXX (5-6 digits). Got: $PR_TITLE"
+            exit 1
+          fi
 
   meta:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -408,45 +408,47 @@ jobs:
         run: |
           SEEN=""
           echo "$COMMITS" | jq -c '.[]' | while read -r commit; do
-            TITLE=$(jq -r '.message' <<<"$commit" | head -n1)
+            MESSAGE=$(jq -r '.message' <<<"$commit")
             SHA=$(jq -r '.id' <<<"$commit")
             AUTHOR=$(jq -r '.author.username // .author.name' <<<"$commit")
-            if [[ ! "$TITLE" =~ (ADDON-[0-9]{5,6})([^0-9]|$) ]]; then
+            TICKETS=$(grep -oP 'ADDON-[0-9]{5,6}(?![0-9])' <<<"$MESSAGE" | sort -u)
+            if [[ -z "$TICKETS" ]]; then
               continue
             fi
-            TICKET="${BASH_REMATCH[1]}"
-            if [[ " $SEEN " == *" $TICKET "* ]]; then
-              continue
-            fi
-            SEEN="$SEEN $TICKET"
+            while read -r TICKET; do
+              if [[ " $SEEN " == *" $TICKET "* ]]; then
+                continue
+              fi
+              SEEN="$SEEN $TICKET"
 
-            COMMIT_URL="https://github.com/$REPO/commit/$SHA"
-            if ! PR_URL=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].html_url // ""' 2>/dev/null); then
-              PR_URL=""
-            fi
-            BODY=$(jq -n \
-              --arg author "$AUTHOR" --arg branch "$BRANCH" --arg repo "$REPO" \
-              --arg commit_url "$COMMIT_URL" --arg sha "${SHA:0:7}" --arg pr_url "$PR_URL" \
-              '{body: {type: "doc", version: 1, content: [
-                {type: "paragraph", content: [
-                  {type: "text", text: ($author + " mentioned this issue in a commit of " + $repo + " on branch " + $branch + ":")}
-                ]},
-                {type: "paragraph", content: (
-                  [{type: "text", text: $sha, marks: [{type: "link", attrs: {href: $commit_url}}]}]
-                  + (if $pr_url != "" then
-                      [{type: "text", text: " (via "},
-                       {type: "text", text: "PR", marks: [{type: "link", attrs: {href: $pr_url}}]},
-                       {type: "text", text: ")"}]
-                    else [] end)
-                )}
-              ]}}')
+              COMMIT_URL="https://github.com/$REPO/commit/$SHA"
+              if ! PR_URL=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].html_url // ""' 2>/dev/null); then
+                PR_URL=""
+              fi
+              BODY=$(jq -n \
+                --arg author "$AUTHOR" --arg branch "$BRANCH" --arg repo "$REPO" \
+                --arg commit_url "$COMMIT_URL" --arg sha "${SHA:0:7}" --arg pr_url "$PR_URL" \
+                '{body: {type: "doc", version: 1, content: [
+                  {type: "paragraph", content: [
+                    {type: "text", text: ($author + " mentioned this issue in a commit of " + $repo + " on branch " + $branch + ":")}
+                  ]},
+                  {type: "paragraph", content: (
+                    [{type: "text", text: $sha, marks: [{type: "link", attrs: {href: $commit_url}}]}]
+                    + (if $pr_url != "" then
+                        [{type: "text", text: " (via "},
+                         {type: "text", text: "PR", marks: [{type: "link", attrs: {href: $pr_url}}]},
+                         {type: "text", text: ")"}]
+                      else [] end)
+                  )}
+                ]}}')
 
-            echo "Commenting on $TICKET for commit ${SHA:0:7}"
-            curl --fail --silent --show-error \
-              -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN" \
-              -H "Content-Type: application/json" \
-              -X POST "$JIRA_BASE_URL/rest/api/3/issue/$TICKET/comment" \
-              -d "$BODY" || echo "::warning::Failed to comment on $TICKET for commit ${SHA:0:7}"
+              echo "Commenting on $TICKET for commit ${SHA:0:7}"
+              curl --fail --silent --show-error \
+                -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN" \
+                -H "Content-Type: application/json" \
+                -X POST "$JIRA_BASE_URL/rest/api/3/issue/$TICKET/comment" \
+                -d "$BODY" || echo "::warning::Failed to comment on $TICKET for commit ${SHA:0:7}"
+            done <<<"$TICKETS"
           done
 
   meta:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   * [[Job] check-docs-changes](#job-check-docs-changes)
   * [[Job] setup-workflow](#job-setup-workflow)
   * [[Job] validate-pr-title](#job-validate-pr-title)
+  * [[Job] comment-on-jira](#job-comment-on-jira)
   * [[Job] meta](#job-meta)
   * [[Job] fossa-scan](#job-fossa-scan)
   * [[Job] fossa-test](#job-fossa-test)
@@ -279,6 +280,23 @@ gitGraph
 **Pass/fail behaviour:**
 
 - Fails if the PR title does not follow conventional commit format (e.g. `feat:`, `fix:`, `chore:`, etc.) or if it is marked as WIP.
+
+**Artifacts:**
+
+- No additional artifacts.
+
+
+## [Job] comment-on-jira
+
+**Description:**
+
+- Runs only on push events to `main` or `develop`.
+- Scans the commit messages in the push for an `ADDON-XXXXX` Jira ticket reference (5-6 digits) and posts a comment on each referenced ticket linking back to the commit (and originating PR, if found).
+- Requires the `JIRA_BASE_URL`, `JIRA_USER_EMAIL`, and `JIRA_API_TOKEN` secrets to be configured; the Jira user needs comment permission on the referenced tickets.
+
+**Pass/fail behaviour:**
+
+- Never fails the workflow: a failed Jira API call only logs a warning.
 
 **Artifacts:**
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ gitGraph
 
 - Runs only on push events to `main` or `develop`.
 - Scans the commit messages in the push for an `ADDON-XXXXX` Jira ticket reference (5-6 digits) and posts a comment on each referenced ticket linking back to the commit (and originating PR, if found).
-- Requires the `JIRA_BASE_URL`, `JIRA_USER_EMAIL`, and `JIRA_API_TOKEN` secrets to be configured; the Jira user needs comment permission on the referenced tickets.
+- Requires the `ATLASSIAN_EMAIL` and `ATLASSIAN_TOKEN` secrets to be configured; the Atlassian user needs comment permission on the referenced tickets in `https://splunk.atlassian.net`.
 
 **Pass/fail behaviour:**
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ gitGraph
 **Description:**
 
 - Runs only on push events to `main` or `develop`.
-- Scans the commit messages in the push for an `ADDON-XXXXX` Jira ticket reference (5-6 digits) and posts a comment on each referenced ticket linking back to the commit (and originating PR, if found).
+- Scans the commit messages in the push for an `ADDON-XXXXX` Jira ticket reference (5-6 digits) and posts a comment on each referenced ticket (e.g. "*author* mentioned this issue in a commit of *repo* on branch *branch*:") linking back to the commit (and originating PR, if found).
 - Requires the `ATLASSIAN_EMAIL` and `ATLASSIAN_TOKEN` secrets to be configured; the Atlassian user needs comment permission on the referenced tickets in `https://splunk.atlassian.net`.
 
 **Pass/fail behaviour:**


### PR DESCRIPTION
## Summary
- Adds a step to the `validate-pr-title` job that enforces `ADDON-XXXXX` (5–6 digit Jira ticket number) in the PR title, failing with a clear `::error::` annotation if missing (runs after the existing semantic PR title check).
- Adds a new `comment-on-jira` job: on push to `main`/`develop`, scans commit messages for `ADDON-XXXXX` references and posts a comment on each referenced ticket linking back to the commit (and originating PR, if found), worded to match the existing GitLab→Jira integration convention (`{author} mentioned this issue in a commit of {repo} on branch {branch}:`).
- Auth via `ATLASSIAN_EMAIL`/`ATLASSIAN_TOKEN` secrets (hardcoded `https://splunk.atlassian.net` base URL), matching the naming convention already used by `addonfactory-docs-on-github-integration`; posts via raw Jira REST API v3 + ADF body rather than `atlassian/gajira-comment` (which has a known RCE, CVE-2020-14189).
- Never fails the workflow: a failed Jira API call only logs a `::warning::`.

## Test plan
- [x] Open a PR without `ADDON-XXXXX` in the title → job fails with the error message
- [x] Open a PR with `ADDON-12345` or `ADDON-123456` in the title → job passes
- [x] Verify existing semantic PR title validation still works
- [x] **Live end-to-end verification against `splunk/test-addonfactory-repo`** (sandbox repo, temporarily pointed at this branch, reverted to `v5.4` after each round), commenting on real ticket [ADDON-88759](https://splunk.atlassian.net/browse/ADDON-88759):
  - `pull_request` event → `comment-on-jira` correctly `skipped` (job only fires on `push`)
  - Push directly to `main`, no originating PR → comment posted with commit link only, no "via PR" clause ([run](https://github.com/splunk/test-addonfactory-repo/actions/runs/28979594348))
  - Push to `main` via squash-merged PR → comment posted with commit link **and** correct PR link ([run](https://github.com/splunk/test-addonfactory-repo/actions/runs/28979730875), [PR #374](https://github.com/splunk/test-addonfactory-repo/pull/374))
  - Push with a mix of a ticket-referencing and a non-referencing commit → only the referencing commit produced a comment (dedup/skip logic confirmed) ([run](https://github.com/splunk/test-addonfactory-repo/actions/runs/28980385679))
  - Bug found and fixed during testing: initial run 403'd on the PR lookup (job only had `contents: read`) and leaked the raw error JSON into the comment's link `href` ([run](https://github.com/splunk/test-addonfactory-repo/actions/runs/28978879858), see resulting [malformed comment](https://splunk.atlassian.net/browse/ADDON-88759)) — fixed by adding `pull-requests: read` and guarding the `gh api` failure path (`1c8ba82`)
  - Final wording verified live: "mkolasinski-splunk mentioned this issue in a commit of splunk/test-addonfactory-repo on branch main:" ([run](https://github.com/splunk/test-addonfactory-repo/actions/runs/28980385679))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
