### PR TITLE
Revert "fix: split run-spl2-tests by pipeline directory for parallel execution ADDON-88924"

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -213,7 +213,6 @@ jobs:
       exit-first: ${{ steps.determine-test-execution-flags.outputs.exit-first }}
       execute-unit: ${{ steps.determine-test-execution-flags.outputs.execute_unit }}
       execute-gs-scorecard: ${{ steps.determine-test-execution-flags.outputs.execute_gs_scorecard }}
-      spl2-pipelines: ${{ steps.determine-test-execution-flags.outputs.spl2_pipelines }}
       s3_bucket_k8s: ${{ steps.k8s-environment.outputs.s3_bucket }}
       argo_server_domain_k8s: ${{ steps.k8s-environment.outputs.argo_server_domain }}
       argo_token_secret_id_k8s: ${{ steps.k8s-environment.outputs.argo_token_secret_id }}
@@ -250,7 +249,6 @@ jobs:
             EXECUTION_FLAGS["$test_type"]="false"
           done
 
-          SPL2_PIPELINES="[]"
           if [[ "${{ needs.check-docs-changes.outputs.docs-only }}" == "true" ]]; then
             echo "Docs-only changes detected. No tests will be executed."
           else
@@ -267,21 +265,6 @@ jobs:
             if [[ -d "package/default/data/spl2" ]]; then
               TESTS_TO_CONSIDER_FOR_EXECUTION+=("execute_spl2")
               echo "spl2::true"
-
-              declare -a SPL2_PIPELINE_DIRS
-              while read -r PIPELINE_DIR; do
-                # Tests can live at any depth under a pipeline dir (rglob), not just directly inside it.
-                if find "$PIPELINE_DIR" \( -name '*.test.json' -o -name '*.test.spl2' \) -print -quit | grep -q .; then
-                  SPL2_PIPELINE_DIRS+=("$(basename "$PIPELINE_DIR")")
-                fi
-              done < <(find package/default/data/spl2 -mindepth 1 -maxdepth 1 -type d | sort)
-              # Test files directly under data/spl2 (no pipeline subdir) get their own "__root__" entry.
-              if find package/default/data/spl2 -mindepth 1 -maxdepth 1 \( -name '*.test.json' -o -name '*.test.spl2' \) -print -quit | grep -q .; then
-                SPL2_PIPELINE_DIRS+=("__root__")
-              fi
-              if [[ ${#SPL2_PIPELINE_DIRS[@]} -gt 0 ]]; then
-                SPL2_PIPELINES=$(printf '%s\n' "${SPL2_PIPELINE_DIRS[@]}" | jq -R . | jq -sc .)
-              fi
             fi
 
             found_unit_test=false
@@ -361,8 +344,6 @@ jobs:
               EXECUTION_FLAGS["execute_gs_scorecard"]="true"
             fi
           fi
-          echo "spl2_pipelines=${SPL2_PIPELINES}" >> "$GITHUB_OUTPUT"
-          echo "spl2 pipelines: ${SPL2_PIPELINES}"
           echo "Tests to be executed:"
           for test_type in "${TESTSET[@]}"; do
             echo "$test_type""=${EXECUTION_FLAGS["$test_type"]}" >> "$GITHUB_OUTPUT"
@@ -1420,10 +1401,6 @@ jobs:
     if: ${{ !cancelled() && needs.setup-workflow.outputs.execute-spl2 == 'true'}}
     needs:
       - setup-workflow
-    strategy:
-      fail-fast: false
-      matrix:
-        pipeline: ${{ fromJSON(needs.setup-workflow.outputs.spl2-pipelines) }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/splunk/spl2-testing-base:latest
@@ -1445,29 +1422,16 @@ jobs:
           git_path="$(pwd)"
           echo "$git_path"
           git config --global --add safe.directory "$git_path"
-      - name: Stage root-level spl2 tests  # tests directly under data/spl2 (no pipeline subdir) get copied into their own dir
-        if: ${{ matrix.pipeline == '__root__' }}
-        run: |
-          ROOT_PIPELINE_DIR="package/default/data/spl2-pipeline-root"
-          mkdir -p "$ROOT_PIPELINE_DIR"
-          find package/default/data/spl2 -mindepth 1 -maxdepth 1 \( -name '*.spl2' -o -name '*.test.json' \) -exec cp {} "$ROOT_PIPELINE_DIR/" \;
       - name: Run spl2 tests
-        shell: bash
         run: |
-          echo "Running SPL2 Tests for pipeline: ${{ matrix.pipeline }}"
-          if [[ "${{ matrix.pipeline }}" == "__root__" ]]; then
-            TEST_DIR="package/default/data/spl2-pipeline-root"
-          else
-            TEST_DIR="package/default/data/spl2/${{ matrix.pipeline }}"
-          fi
-          # code_dir must match test_dir, otherwise discovery falls back to the other dir and re-pulls in every other pipeline's tests.
-          spl2_tests_run cli --test_dir "$TEST_DIR" --code_dir "$TEST_DIR" -n 8 --ignore_additional_fields_in_actual --ignore_empty_strings -o log_cli=true --log-cli-level=INFO --verbose --junitxml "test-results/report-${{ matrix.pipeline }}.xml"
+          echo "Running SPL2 Tests"
+          spl2_tests_run cli -n 8 --ignore_additional_fields_in_actual --ignore_empty_strings -o log_cli=true --log-cli-level=INFO --verbose --junitxml test-results/report.xml
       - name: Test Report
         id: test_report
         uses: dorny/test-reporter@v3.0.0
         if: ${{ !cancelled() }}
         with:
-          name: spl2 test report (${{ matrix.pipeline }})
+          name: spl2 test report
           path: "test-results/*.xml"
           reporter: java-junit
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Reverts splunk/addonfactory-workflow-addon-release#513
No longer needed due to improvements on spl2-cli side