### PR TITLE
fix: make GS Scorecard non-blocking for releases (#505) [sync develop to main]

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -937,19 +937,18 @@ jobs:
         with:
           name: gs-scorecard-report
           path: ./gs_scorecard.json
-      - name: Print and verify GS Scorecard report
+      - name: Print GS Scorecard report
         run: |
           if [ ! -f ./gs_scorecard.json ]; then
-            echo "::error::GS Scorecard report not found"
-            exit 1
+            echo "::warning::GS Scorecard report not found"
+            exit 0
           fi
           echo "::group::GS Scorecard Report"
           jq . ./gs_scorecard.json
           echo "::endgroup::"
           passed=$(jq -r '.result.passed' ./gs_scorecard.json)
           if [ "$passed" != "true" ]; then
-            echo "::error::GS Scorecard failed"
-            exit 1
+            echo "::warning::GS Scorecard did not pass - this is informational only and will not block the release"
           fi
 
   setup:
@@ -3231,18 +3230,6 @@ jobs:
         id: check
         shell: bash
         run: |
-          # GS Scorecard: must have run for PRs to main (result doesn't matter, but skipped = blocked)
-          GS_RESULT=$(echo "$NEEDS" | jq -r '.["run-gs-scorecard"].result')
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.base_ref }}" == "main" ]] && [[ "$GS_RESULT" == "skipped" ]] && [[ "${{ needs.check-docs-changes.outputs.docs-only }}" != "true" ]]; then
-            echo "::error::GS Scorecard is required for merging PRs to main. To unblock merging please add the 'execute_gs_scorecard' label and re-run the workflow."
-            echo "## GS Scorecard Required" >> "$GITHUB_STEP_SUMMARY"
-            echo "Add the \`execute_gs_scorecard\` label to this PR and re-run the workflow. GS Scorecard must complete before merging to main (result does not need to pass)." >> "$GITHUB_STEP_SUMMARY"
-            echo "run-publish=false" >> "$GITHUB_OUTPUT"
-            echo "Publish conditions are not met."
-            exit 1
-          fi
-
-          # Exclude run-gs-scorecard from the general check since it has its own handling above
           RUN_PUBLISH=$(echo "$NEEDS" | jq 'del(.["run-gs-scorecard"]) | .[] | select((.result != "skipped") and .result != "success") | length == 0')
           if [[ "$RUN_PUBLISH" != *'false'* ]] && [[ "${{ needs.check-docs-changes.outputs.docs-only }}" == 'false' ]]
           then


### PR DESCRIPTION
## Summary

- GS Scorecard tool remains available via `execute_gs_scorecard` label — developers can still use it
- Scorecard results (pass/fail/missing) are now reported as `::warning::` instead of `::error::` and never cause the job to fail
- Removed the `pre-publish` gate that blocked releases when scorecard was skipped on PRs to main
- Fixes cases where scorecard flags checks as not checked, unintentionally blocking releases


https://github.com/splunk/splunk-add-on-for-cisco-esa/actions/runs/27544575031/job/81415137332?pr=480#step:9:268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

### Description

(PR description goes here)

### Checklist

- [ ] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
(for each selected checkbox, the corresponding test results link should be listed here)
