### PR TITLE
chore: migrate publish job from PAT to GitHub App authentication

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -83,9 +83,6 @@ on:
         type: string
         default: "[]"
     secrets:
-      GH_TOKEN_ADMIN:
-        description: Github admin token
-        required: true
       GH_APP_CLIENT_ID:
         description: GitHub App Client ID for authentication
         required: true
@@ -3495,6 +3492,13 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -3505,7 +3509,7 @@ jobs:
         id: semantic
         uses: splunk/semantic-release-action@v1.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
@@ -3516,7 +3520,7 @@ jobs:
         id: custom
         uses: "softprops/action-gh-release@v3"
         with:
-          token: "${{ secrets.GH_TOKEN_ADMIN }}"
+          token: "${{ steps.app-token.outputs.token }}"
           tag_name: v${{ github.event.inputs.custom-version }}
           target_commitish: "${{github.ref_name}}"
           make_latest: false


### PR DESCRIPTION
## Summary

- Removes `GH_TOKEN_ADMIN` (service account PAT) from the `workflow_call` secrets — it is no longer accepted by callers
- Adds a **Generate app token** step at the start of the `publish` job using `actions/create-github-app-token@v3` with `GH_APP_CLIENT_ID`/`GH_APP_PRIVATE_KEY`, consistent with every other job in this workflow
- Passes `steps.app-token.outputs.token` to `splunk/semantic-release-action` (git push + tag to `main`) and `softprops/action-gh-release` (custom-version releases)

## Why the PAT didn't work

The `main` branch ruleset on consumer repos has a bypass actor for the `splunk-ta-helper` GitHub App. A PAT from the service account is not the app, so pushes from semantic-release were rejected with 403. The short-lived app token passes the bypass check.

## Callers must remove `GH_TOKEN_ADMIN` from their secrets block

```yaml
# remove this line from your workflow
GH_TOKEN_ADMIN: ${{ secrets.GH_TOKEN_ADMIN }}
```

Ensure `SPLUNK_TA_HELPER_APP_ID` / `SPLUNK_TA_HELPER_PRIVATE_KEY` are set as repo secrets and passed as `GH_APP_CLIENT_ID` / `GH_APP_PRIVATE_KEY`.

## Test plan

- [ ] Trigger a push to `main` on a consumer repo and verify the `publish` job completes (semantic-release pushes signed tag + commit without 403)
- [ ] Trigger a `workflow_dispatch` with `custom-version` set and verify `action-gh-release` creates the release successfully
- [ ] Confirm `GH_TOKEN_ADMIN` secret can be removed from consumer repos after adopting this version

🤖 Generated with [Claude Code](https://claude.com/claude-code)