### PR TITLE
fix: run full Splunk matrix on PR/push to release/* branches (ADDON-88928)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -493,7 +493,9 @@ jobs:
             
           else
             if [[ "${{ github.base_ref }}" == "main" || "${{ github.ref_name }}" == "main" ]] || \
-              [[ "${{ github.ref_name }}" == "develop" && "${{ github.event_name }}" == "push" ]]; then
+              [[ "${{ github.ref_name }}" == "develop" && "${{ github.event_name }}" == "push" ]] || \
+              [[ "${{ startsWith(github.base_ref, 'release/') }}" == "true" ]] || \
+              [[ "${{ startsWith(github.ref_name, 'release/') }}" == "true" && "${{ github.event_name }}" == "push" && "${{ inputs.execute-tests-on-push-to-release }}" == "true" ]]; then
               wfe_run_on_splunk_latest="false"
             else
               wfe_run_on_splunk_latest="true"

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ gitGraph
 
 - Determines which Splunk and SC4S versions to run tests with.
 - Outputs matrices for supported and latest Splunk versions, SC4S versions, and vendor matrices for modinput/UI tests.
-- On schedule events, always uses latest Splunk only. On PRs to `main` or push to `main`/`develop`, uses the full supported matrix (unless overridden by `wfe-run-on-splunk-latest` input).
+- On schedule events, always uses latest Splunk only. On PRs to `main` or `release/*`, or push to `main`/`develop`/`release/*` (the latter only when `execute-tests-on-push-to-release` is `true`), uses the full supported matrix (unless overridden by `wfe-run-on-splunk-latest` input).
 
 ## [Job] fossa-scan
 


### PR DESCRIPTION
## Summary

ADDON-88928: PR/push targeting `release/*` branches was running Splunk tests against latest-Splunk-only instead of the full supported matrix. The `meta` job's `determine_splunk` step only special-cased `main`/`develop`, so `release/*` fell into the latest-only `else` branch — exactly where full-matrix coverage matters most before cutting a release.

## Change

- `reusable-build-test-release.yml`: extend the `determine_splunk` condition to also treat `release/*` as full-matrix — for PR (`base_ref`) and for push (`ref_name`, gated by `execute-tests-on-push-to-release` to match the existing push gate).
- `README.md`: document the `release/*` full-matrix behavior.

## Validated (test-addonfactory-repo)

- PR into a `release/*` base (test-addonfactory-repo#376): `meta` job succeeded; the job-summary consumed the **full 5-version matrix** `[10.2.5, 10.0.8, 9.4.13, 9.3.14, 10.4.1]` instead of latest-only `[10.4.1]`. AC confirmed.
- A control PR against unmodified `@develop` reproduced a pre-existing `startup_failure` (missing `GH_TOKEN_ADMIN` passthrough in the caller), proving the failure was environmental and independent of this change; adding the passthrough unblocked the run.

JIRA: https://splunk.atlassian.net/browse/ADDON-88928