### PR TITLE
fix: restore check-run URL in Test Report steps (ADDON-88923)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1545,6 +1545,7 @@ jobs:
           name: spl2 test report
           path: "test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
@@ -1763,6 +1764,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
@@ -2041,6 +2043,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.browser }} ${{ matrix.vendor-version.image }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
@@ -2317,6 +2320,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
@@ -2592,6 +2596,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} ${{ matrix.marker }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
@@ -2856,6 +2861,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ matrix.vendor-version.image }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
@@ -3125,6 +3131,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ steps.os-name-version.outputs.os-name }} ${{ steps.os-name-version.outputs.os-version }}  test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |
@@ -3387,6 +3394,7 @@ jobs:
           name: splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} ${{ env.SPL2_TEST_TYPE }} test report
           path: "${{ needs.setup.outputs.directory-path }}/test-results/*.xml"
           reporter: java-junit
+          use-actions-summary: false
       - name: Parse JUnit XML
         if: ${{ !cancelled() }}
         run: |


### PR DESCRIPTION
## Summary
- `dorny/test-reporter@v3.0.0` (bumped in #512) defaults `use-actions-summary` to `true`, which skips check-run creation entirely — the code path that sets the `url`/`url_html` outputs never runs. That's why the Test Report stage's rendering changed and why `job_summary.txt`'s report-link column went empty.
- Sets `use-actions-summary: false` on all 8 `Test Report` steps to restore v1.9.1 behavior: check run created, `url_html` populated, `job_summary.txt` -> artifact -> aggregated Report Link table works as before.

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [ ] Confirm a downstream TA run shows a populated Report Link in the aggregated summary table