### PR TITLE
fix: wire ADDON-87662 python.version support into reusable workflow

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -39,7 +39,7 @@ on:
         required: false
         description: "branch for k8s manifests to run the tests on"
         type: string
-        default: "v4.2"
+        default: "v4.3"
       scripted-inputs-os-list:
         required: false
         description: "list of OS used for scripted input tests"
@@ -481,7 +481,7 @@ jobs:
           submodules: false
           persist-credentials: false
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v3.2
+        uses: splunk/addonfactory-test-matrix-action@v3.3
         with:
           features: PYTHON39
       - id: determine_splunk
@@ -1376,7 +1376,7 @@ jobs:
         timeout-minutes: 20
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1624,7 +1624,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -1908,7 +1908,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2185,7 +2185,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2460,7 +2460,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2723,7 +2723,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -2998,7 +2998,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}
@@ -3255,7 +3255,7 @@ jobs:
         continue-on-error: true
         env:
           ARGO_TOKEN: ${{ steps.get-argo-token.outputs.argo-token }}
-        uses: splunk/wfe-test-runner-action@v5.2
+        uses: splunk/wfe-test-runner-action@main
         with:
           splunk: ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }}
           test-type: ${{ env.TEST_TYPE }}


### PR DESCRIPTION
## Summary
- Sibling validation for ADDON-87662 (Splunk 9.4 `python.version` support in `server.conf`) passed against real TAs via throwaway sibling PRs (not for merge): [salesforce#897](https://github.com/splunk/splunk-add-on-for-salesforce/pull/897), [aws#1707](https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1707), [sysmon#369](https://github.com/splunk/splunk-add-on-for-microsoft-sysmon/pull/369).
- Bumps default pins so `release/5.6.0` actually picks up the capability:
  - `k8s-manifests-branch` default `v4.2` -> `v4.3` (postStart hook sets `python.version` in `server.conf` for Splunk 9.4 variants) — [ta-automation-k8s-manifests#148](https://github.com/splunk/ta-automation-k8s-manifests/pull/148)
  - `wfe-test-runner-action@v5.2` -> `@main` (`server-conf-python-version` input) — [wfe-test-runner-action#50](https://github.com/splunk/wfe-test-runner-action/pull/50) (no release tag yet, pinning to `main` for now)
  - `addonfactory-test-matrix-action@v3.2` -> `@v3.3` (`supportedSplunkModinput` output with `python.version` variants) — [addonfactory-test-matrix-action#213](https://github.com/splunk/addonfactory-test-matrix-action/pull/213)

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [ ] Confirm downstream TA CI run picks up python.version variants correctly