### PR TITLE
fix: pass explicit branch to fossa analyze to avoid master fallback

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -518,7 +518,7 @@ jobs:
         id: fossa-scan
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          fossa analyze --debug 2>&1 | tee /tmp/fossa_analyze_output.txt
+          fossa analyze --branch "$FOSSA_BRANCH" --debug 2>&1 | tee /tmp/fossa_analyze_output.txt
           exit_code="${PIPESTATUS[0]}"
           FOSSA_REPORT_URL=$(grep -o 'https://app.fossa.com[^ ]*' /tmp/fossa_analyze_output.txt || true)
           echo "url=$FOSSA_REPORT_URL"
@@ -527,12 +527,14 @@ jobs:
           exit "$exit_code"
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+          FOSSA_BRANCH: ${{ github.head_ref || github.ref_name }}
       - name: run fossa test and capture output
         if: success()
         run: |
-          fossa test --debug 2>&1 | tee fossa-test-output.txt || true
+          fossa test --branch "$FOSSA_BRANCH" --debug 2>&1 | tee fossa-test-output.txt || true
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+          FOSSA_BRANCH: ${{ github.head_ref || github.ref_name }}
       - name: upload THIRDPARTY file
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -531,10 +531,9 @@ jobs:
       - name: run fossa test and capture output
         if: success()
         run: |
-          fossa test --branch "$FOSSA_BRANCH" --debug 2>&1 | tee fossa-test-output.txt || true
+          fossa test --debug 2>&1 | tee fossa-test-output.txt || true
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-          FOSSA_BRANCH: ${{ github.head_ref || github.ref_name }}
       - name: upload THIRDPARTY file
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Problem
The `fossa-scan` job checks out the PR merge ref via `actions/checkout`, which leaves the working tree in a detached HEAD state. `fossa-cli` can't infer a git branch from a detached HEAD, so it silently falls back to the FOSSA project's default branch (`master`) for the report URL and every vulnerability/license issue link — regardless of the PR's actual source or target branch.

Confirmed in a real run: https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/30452628723/job/90578165543 (PR targeting `release/v8.2.1`, but every FOSSA issue link points at `refs/branch/master/...`).

## Fix
Pass `--branch` explicitly to `fossa analyze`, derived from `github.head_ref || github.ref_name` (covers `pull_request`, `push`, and `workflow_dispatch` triggers). `fossa test` is left untouched — it has no `--branch` option; it resolves the build via project + revision, which already matches what `fossa analyze` just registered.

## Verification
Reproduced the fix end-to-end against `splunk/splunk-add-on-for-amazon-web-services` by temporarily pointing its `build-test-release.yml` at this branch and running the workflow (PR + `workflow_dispatch`). Confirmed via job logs:
- `Using branch: test/verify-fossa-branch-fix` (previously `No branch (detached HEAD)` → fell back to `master`)
- Report URL and every issue link scoped to `refs/branch/test%2Fverify-fossa-branch-fix/...`
- `fossa test` ran cleanly with real results (no `Invalid option` error)

Verification PR (closed, not merged): https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1721