### PR TITLE
fix: allow approved pre-publish override

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -3688,12 +3688,38 @@ jobs:
               echo "Publish conditions are not met."
           fi
 
-  manual-publish-approval:
+  verify-publish-override:
     if: ${{ !cancelled() && needs.pre-publish.outputs.run-publish != 'true' && (github.event_name == 'push' || needs.validate-custom-version.result == 'success') }}
-    name: Approve publish without successful pre-publish
+    name: Verify publish override environment
     needs:
       - pre-publish
       - validate-custom-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Verify environment and required reviewers
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ENVIRONMENT=$(gh api "repos/${{ github.repository }}/environments/publish-override") || {
+            echo "::error::The publish-override environment does not exist."
+            exit 1
+          }
+          if [[ $(jq '[.protection_rules[]? | select(.type == "required_reviewers") | .reviewers[]?] | length' <<< "$ENVIRONMENT") -eq 0 ]]; then
+            echo "::error::The publish-override environment has no required reviewers."
+            exit 1
+          fi
+
+  manual-publish-approval:
+    if: ${{ !cancelled() && needs.verify-publish-override.result == 'success' }}
+    name: Approve publish without successful pre-publish
+    needs: verify-publish-override
     runs-on: ubuntu-latest
     environment: publish-override
     steps:

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -136,7 +136,7 @@ permissions:
   contents: read
   packages: read
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   PYTHON_VERSION: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -3694,8 +3694,14 @@ jobs:
     needs:
       - pre-publish
       - validate-custom-version
+      - build
     runs-on: ubuntu-latest
     steps:
+      - name: Verify required build
+        if: ${{ needs.build.result != 'success' }}
+        run: |
+          echo "::error::The build job must succeed and cannot be overridden."
+          exit 1
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -3688,12 +3688,25 @@ jobs:
               echo "Publish conditions are not met."
           fi
 
+  manual-publish-approval:
+    if: ${{ !cancelled() && needs.pre-publish.outputs.run-publish != 'true' && (github.event_name == 'push' || needs.validate-custom-version.result == 'success') }}
+    name: Approve publish without successful pre-publish
+    needs:
+      - pre-publish
+      - validate-custom-version
+    runs-on: ubuntu-latest
+    environment: publish-override
+    steps:
+      - name: Record approval
+        run: echo "Publish was manually approved despite unmet pre-publish conditions."
+
   publish:
-    if: ${{ !cancelled() && needs.pre-publish.outputs.run-publish == 'true' && (github.event_name == 'push' || needs.validate-custom-version.result == 'success') }}
+    if: ${{ !cancelled() && (needs.pre-publish.outputs.run-publish == 'true' || needs.manual-publish-approval.result == 'success') && (github.event_name == 'push' || needs.validate-custom-version.result == 'success') }}
     name: ${{ github.event.inputs.custom-version == '' &&  'publish' ||  'publish-custom-version' }}
     needs:
       - pre-publish
       - validate-custom-version
+      - manual-publish-approval
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -136,7 +136,7 @@ permissions:
   contents: read
   packages: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
   PYTHON_VERSION: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -3753,6 +3753,23 @@ jobs:
           client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+      - name: Verify approved commit is still current
+        if: ${{ needs.manual-publish-approval.result == 'success' && github.ref_type == 'branch' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APPROVED_SHA: ${{ github.sha }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          ENCODED_BRANCH=$(jq -rn --arg branch "$BRANCH_NAME" '$branch | @uri')
+          CURRENT_SHA=$(gh api "repos/$REPOSITORY/git/ref/heads/$ENCODED_BRANCH" --jq '.object.sha') || {
+            echo "::error::Unable to verify the current branch tip."
+            exit 1
+          }
+          if [[ "$CURRENT_SHA" != "$APPROVED_SHA" ]]; then
+            echo "::error::This approval is for $APPROVED_SHA, but $BRANCH_NAME now points to $CURRENT_SHA. Run and approve the latest workflow instead."
+            exit 1
+          fi
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -3776,7 +3793,7 @@ jobs:
         with:
           token: "${{ steps.app-token.outputs.token }}"
           tag_name: v${{ github.event.inputs.custom-version }}
-          target_commitish: "${{github.ref_name}}"
+          target_commitish: "${{ github.sha }}"
           make_latest: false
       - name: Download package-deployment
         if: ${{ steps.semantic.outputs.new_release_published == 'true' || steps.custom.outputs.upload_url  != '' }}

--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,8 @@ argo-logs
 
 - Release readiness is blocked when `fossa-vulnerability-test` fails, as `pre-publish` depends on it directly via the `needs` dependency.
 
+- For a publish-capable run where the pre-publish conditions are not met, `manual-publish-approval` waits for approval through the `publish-override` environment. After approval, publishing proceeds. Configure that environment with the appropriate required reviewers before using the override.
+
 **Troubleshooting steps for failures if any**
 
 - In the logs it outputs a json with the info of stages and their pass/fail status. <br /> 

--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,8 @@ argo-logs
 
 - It releases a new release tag in the repository and uploads the assets to the release.
 
+- After a manual override approval, publishing verifies that the approved commit is still the current branch tip. Superseded runs fail before creating a tag or release.
+
 **Troubleshooting steps for failures if any**
 
 - This stage depends majorly on Semantic release action so if Publish is failing check for logs or issues raised recently in Semantic release action.

--- a/README.md
+++ b/README.md
@@ -1044,7 +1044,7 @@ argo-logs
 
 - Release readiness is blocked when `fossa-vulnerability-test` fails, as `pre-publish` depends on it directly via the `needs` dependency.
 
-- For a publish-capable run where the pre-publish conditions are not met, `manual-publish-approval` waits for approval through the `publish-override` environment. After approval, publishing proceeds. Configure that environment with the appropriate required reviewers before using the override.
+- For a publish-capable run where the pre-publish conditions are not met, the workflow verifies that the `publish-override` environment exists and has required reviewers. If it is missing or unprotected, the override fails. Otherwise, `manual-publish-approval` waits for environment approval before publishing proceeds.
 
 **Troubleshooting steps for failures if any**
 

--- a/README.md
+++ b/README.md
@@ -1071,8 +1071,6 @@ argo-logs
 
 - After a manual override approval, publishing verifies that the approved commit is still the current branch tip. Superseded runs fail before creating a tag or release.
 
-- A newer push to the same branch cancels any older in-progress run of this workflow, including a run waiting for manual publish approval.
-
 **Troubleshooting steps for failures if any**
 
 - This stage depends majorly on Semantic release action so if Publish is failing check for logs or issues raised recently in Semantic release action.

--- a/README.md
+++ b/README.md
@@ -1071,6 +1071,8 @@ argo-logs
 
 - After a manual override approval, publishing verifies that the approved commit is still the current branch tip. Superseded runs fail before creating a tag or release.
 
+- A newer push to the same branch cancels any older in-progress run of this workflow, including a run waiting for manual publish approval.
+
 **Troubleshooting steps for failures if any**
 
 - This stage depends majorly on Semantic release action so if Publish is failing check for logs or issues raised recently in Semantic release action.

--- a/README.md
+++ b/README.md
@@ -1044,7 +1044,7 @@ argo-logs
 
 - Release readiness is blocked when `fossa-vulnerability-test` fails, as `pre-publish` depends on it directly via the `needs` dependency.
 
-- For a publish-capable run where the pre-publish conditions are not met, the workflow verifies that the `publish-override` environment exists and has required reviewers. If it is missing or unprotected, the override fails. Otherwise, `manual-publish-approval` waits for environment approval before publishing proceeds.
+- For a publish-capable run where the pre-publish conditions are not met, the workflow first requires the `build` job to have succeeded, as that job cannot be overridden. It then verifies that the `publish-override` environment exists and has required reviewers. If either requirement is not met, the override fails. Otherwise, `manual-publish-approval` waits for environment approval before publishing proceeds.
 
 **Troubleshooting steps for failures if any**
 


### PR DESCRIPTION
## Summary

Add a controlled manual approval path that allows publishing when selected `pre-publish` conditions are not met.

The normal release path is unchanged: when `pre-publish` returns `run-publish=true`, publishing proceeds automatically. The existing `pre-publish.needs` list and its output-based behavior are unchanged.

## Behavior

| Situation | Result |
| --- | --- |
| `pre-publish` conditions pass | Publish proceeds automatically |
| `pre-publish` conditions fail and `build` succeeds | Wait for approval through `publish-override` |
| `build` fails or is skipped | Override preflight fails; publishing is blocked |
| `publish-override` is missing | Override preflight fails; GitHub cannot silently create an unprotected approval path |
| `publish-override` has no required reviewers | Override preflight fails |
| Approved run is no longer the branch tip | Publish fails before creating a tag or release |
| Pull request run | No publish approval is requested |

Custom releases are pinned to the approved `github.sha` rather than a mutable branch name.

## Repository configuration

Each consumer add-on repository must create an environment named exactly:

```text
publish-override
```

Configure it with at least one required reviewer. Preventing self-review and disabling administrator bypass are recommended for production repositories. No environment secrets or variables are required.

## Validation

- repository-pinned `actionlint`
- `pre-commit run --files .github/workflows/reusable-build-test-release.yml README.md`
- `git diff --check`
- branch-tip API lookup tested with slash-containing branch names
- required-reviewer detection tested with protected and unprotected environment responses

## Follow-up

Add the appropriate `ADDON-xxxxx` Jira key to the PR title; no ticket key was supplied with this change.
