### PR TITLE
fix: update AppInspect CLI action to v2.15.0 (ADDON-85469)

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1262,7 +1262,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.13.0
+        uses: splunk/appinspect-cli-action@v2.15.0
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
### Description

Updates the AppInspect CLI action used by the reusable workflow from
v2.13.0 to v2.15.0.

The v2.15.0 action includes splunk-appinspect 4.3.0.

Jira: https://splunk.atlassian.net/browse/ADDON-85469
Action release: https://github.com/splunk/appinspect-cli-action/releases/tag/v2.15.0

This is a focused dependency update. No workflow inputs, AppInspect tags,
or unrelated dependencies were changed.

### Checklist
- [x] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [x] pull request trigger tests
- [ ] schedule trigger tests
- [ ] workflow errors/warnings reviewed and addressed

### Testing done 
Validated the reusable workflow change using the Splunk Add-on for Apache Web Server.

- TA validation PR: https://github.com/splunk/splunk-add-on-for-apache-web-server/pull/394
- Workflow run: https://github.com/splunk/splunk-add-on-for-apache-web-server/actions/runs/32106617050

All seven AppInspect CLI jobs ran using `splunk/appinspect-cli-action@v2.15.0` and passed:
- cloud
- appapproval
- deprecated_feature
- developer_guidance
- future
- self-service
- manual

The separate `appinspect-api-action@v3.0` job failed with HTTP 400 `Failed to authenticate user`. This appears to be an existing API credential issue and is outside the scope of the AppInspect CLI action upgrade.
