### PR TITLE
fix: handle single summary artifacts

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2003,13 +2003,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-ko*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-ko*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No knowledge-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -2283,13 +2289,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-ui*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-ui-*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No UI-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -2561,13 +2573,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-modinput*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-modinput*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No modinput-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -2838,13 +2856,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-ucc_modinput*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-ucc_modinput*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No UCC modinput-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -3104,13 +3128,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-upgrade*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-upgrade*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No upgrade-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -3375,13 +3405,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-scripted*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-scripted*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No scripted-input-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -3628,13 +3664,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-spl2_integration_tests*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-spl2_integration_tests*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No SPL2 integration-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |


### PR DESCRIPTION
## What changed

- Download test-summary artifacts into a dedicated `summaries/` directory.
- Discover `job_summary.txt` recursively instead of assuming every artifact is extracted into a named subdirectory.
- Apply the fix consistently to knowledge, UI, modinput, UCC modinput, upgrade, scripted-input, and SPL2 integration report jobs.
- Emit an explicit error when no summary files were downloaded.

## Root cause

When `actions/download-artifact@v8` receives a pattern matching a single artifact, its contents can be extracted directly into the configured destination. The existing report steps expected paths such as `summary-ko*/job_summary.txt`, so a one-item test matrix failed in the report aggregation even when its underlying tests passed.

This was observed in the Carbon Black v2.21.3 rollout: the Splunk 10.4.2 knowledge suite passed, but `knowledge-tests-report` failed with `cat: 'summary-ko*/job_summary.txt': No such file or directory`.

## Impact

Single-artifact and multi-artifact test matrices now generate the same report successfully. The explicit missing-artifact error also makes genuine download failures easier to diagnose.

## Validation

- YAML parsed successfully with `yq`.
- `yamlfmt -lint` passed.
- `git diff --check` passed.
- Extracted shell for all seven report jobs passed `bash -n` and ShellCheck.
- Semantic fixtures passed for single-artifact and multi-artifact directory layouts.
- Missing-artifact fixture exited with the expected explicit error.

Full repository actionlint still reports unrelated pre-existing errors on `develop` involving `actions/create-github-app-token@v3` inputs and an existing matrix expression.