### PR TITLE
feat: separate package and test Python versions and use Python 3.13 as default for tests

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -64,9 +64,9 @@ on:
         default: "3.9"
       test-python-version:
         required: false
-        description: "Python version to use for WFE test tooling and test dependencies"
+        description: "Python version to use for WFE test tooling and test dependencies; defaults to python-version"
         type: string
-        default: "3.9"
+        default: ""
       spl2-generate:
         required: false
         description: "Run spl2-generate hook during pre-commit step"
@@ -145,7 +145,7 @@ concurrency:
   cancel-in-progress: true
 env:
   PYTHON_VERSION: ${{ inputs.python-version }}
-  TEST_PYTHON_VERSION: ${{ inputs.test-python-version }}
+  TEST_PYTHON_VERSION: ${{ inputs.test-python-version || inputs.python-version }}
   POETRY_VERSION: "2.2.1"
   POETRY_EXPORT_PLUGIN_VERSION: "1.9.0"
   GS_IMAGE_VERSION: ${{ inputs.gs-image-version }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -59,12 +59,12 @@ on:
         default: "false"
       python-version:
         required: false
-        description: "Python version to use for package build and pre-commit"
+        description: "Python version to use for package build"
         type: string
         default: "3.9"
       test-python-version:
         required: false
-        description: "Python version to use for WFE test tooling and test dependencies; defaults to python-version"
+        description: "Python version to use for pre-commit, WFE test tooling, and test dependencies; defaults to python-version"
         type: string
         default: ""
       spl2-generate:
@@ -715,7 +715,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -59,7 +59,12 @@ on:
         default: "false"
       python-version:
         required: false
-        description: "Python version to use for testing"
+        description: "Python version to use for package build and pre-commit"
+        type: string
+        default: "3.9"
+      test-python-version:
+        required: false
+        description: "Python version to use for WFE test tooling and test dependencies"
         type: string
         default: "3.9"
       spl2-generate:
@@ -140,6 +145,7 @@ concurrency:
   cancel-in-progress: true
 env:
   PYTHON_VERSION: ${{ inputs.python-version }}
+  TEST_PYTHON_VERSION: ${{ inputs.test-python-version }}
   POETRY_VERSION: "2.2.1"
   POETRY_EXPORT_PLUGIN_VERSION: "1.9.0"
   GS_IMAGE_VERSION: ${{ inputs.gs-image-version }}
@@ -1454,12 +1460,12 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
       - name: setup-poetry
         id: setup-poetry
         shell: bash
         run: |
-          python${{ env.PYTHON_VERSION }} -m pip install poetry==${{ env.POETRY_VERSION }}
+          python${{ env.TEST_PYTHON_VERSION }} -m pip install poetry==${{ env.POETRY_VERSION }}
           export POETRY_REPOSITORIES_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_URL=https://github.com/splunk/addonfactory-ucc-test.git
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_USERNAME=${{ secrets.SA_GH_USER_NAME }}
           export POETRY_HTTP_BASIC_SPLUNK_ADD_ON_UCC_MODINPUT_TEST_PASSWORD=${{ steps.app-token.outputs.token }}
@@ -1471,8 +1477,8 @@ jobs:
         env:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          python${{ env.PYTHON_VERSION }} -m venv ~/.dev_venv
-          ~/.dev_venv/bin/python${{ env.PYTHON_VERSION }} -m pip install -r dev_deps/requirements_dev.txt
+          python${{ env.TEST_PYTHON_VERSION }} -m venv ~/.dev_venv
+          ~/.dev_venv/bin/python${{ env.TEST_PYTHON_VERSION }} -m pip install -r dev_deps/requirements_dev.txt
           if [ -f "tests/ucc_modinput_functional/tmp/openapi.json" ]; then
             ~/.dev_venv/bin/ucc-test-modinput gen -o tests/ucc_modinput_functional/tmp/openapi.json -t ${{ steps.download-openapi.outputs.download-path }}/tmp/
           else
@@ -1485,11 +1491,11 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          python${{ env.PYTHON_VERSION }} -m venv ~/.dev_venv
+          python${{ env.TEST_PYTHON_VERSION }} -m venv ~/.dev_venv
           echo "Found requirements_dev.txt. Installing dev dependencies in an isolated environment"
-          ~/.dev_venv/bin/python${{ env.PYTHON_VERSION }} -m pip install -r dev_deps/requirements_dev.txt
+          ~/.dev_venv/bin/python${{ env.TEST_PYTHON_VERSION }} -m pip install -r dev_deps/requirements_dev.txt
           libs_archive=libs_$(basename "$BUILD_NAME" .spl).tgz
-          cp -r ~/.dev_venv/lib/python${{ env.PYTHON_VERSION }}/site-packages/ libs/
+          cp -r ~/.dev_venv/lib/python${{ env.TEST_PYTHON_VERSION }}/site-packages/ libs/
           tar -czf "$libs_archive" libs
           aws s3 cp "$libs_archive" "s3://${{ needs.setup-workflow.outputs.s3_bucket_k8s }}/ta-apps/$libs_archive" --only-show-errors
       - name: upload-swagger-artifacts-to-s3
@@ -1582,7 +1588,7 @@ jobs:
           sc4s-version: ${{ matrix.sc4s.version }}
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
@@ -1832,7 +1838,7 @@ jobs:
           sc4s-version: ${{ matrix.sc4s.version }}
           sc4s-docker-registry: ${{ matrix.sc4s.docker_registry }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
@@ -2119,7 +2125,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           test-browser: ${{ env.TEST_BROWSER }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
@@ -2397,7 +2403,7 @@ jobs:
           vendor-version: ${{ matrix.vendor-version.image }}
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
@@ -2674,7 +2680,7 @@ jobs:
           vendor-version: ${{ matrix.vendor-version.image }}
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ${{ matrix.splunk.serverConfPythonVersion || '' }}
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
@@ -2940,7 +2946,7 @@ jobs:
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
           ta-upgrade-version: ${{ matrix.ta-version-from-upgrade }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token
@@ -3217,7 +3223,7 @@ jobs:
           os-name: ${{ steps.os-name-version.outputs.os-name }}
           os-version: ${{ steps.os-name-version.outputs.os-version }}
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ''
       - name: calculate timeout
         id: calculate-timeout
@@ -3475,7 +3481,7 @@ jobs:
           vendor-version: ${{ matrix.vendor-version.image }}
           sc4s-version: "No"
           k8s-manifests-branch: ${{ needs.setup.outputs.k8s-manifests-branch }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.TEST_PYTHON_VERSION }}
           server-conf-python-version: ''
       - name: Read secrets from AWS Secrets Manager again into environment variables in case credential rotation
         id: update-argo-token

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -64,9 +64,9 @@ on:
         default: "3.9"
       test-python-version:
         required: false
-        description: "Python version to use for pre-commit, WFE test tooling, and test dependencies; defaults to python-version"
+        description: "Python version to use for pre-commit, WFE test tooling, and test dependencies"
         type: string
-        default: ""
+        default: "3.13"
       spl2-generate:
         required: false
         description: "Run spl2-generate hook during pre-commit step"
@@ -145,7 +145,7 @@ concurrency:
   cancel-in-progress: true
 env:
   PYTHON_VERSION: ${{ inputs.python-version }}
-  TEST_PYTHON_VERSION: ${{ inputs.test-python-version || inputs.python-version }}
+  TEST_PYTHON_VERSION: ${{ inputs.test-python-version }}
   POETRY_VERSION: "2.2.1"
   POETRY_EXPORT_PLUGIN_VERSION: "1.9.0"
   GS_IMAGE_VERSION: ${{ inputs.gs-image-version }}
@@ -759,7 +759,7 @@ jobs:
     with:
       block_mode: "policy"
 
-  run-unit-tests-py39:
+  run-unit-tests:
     name: run-unit-tests (${{ inputs.python-version }})
     runs-on: ubuntu-22.04
     needs:
@@ -918,10 +918,10 @@ jobs:
       - pre-commit
       - review_secrets
       - semgrep
-      - run-unit-tests-py39
+      - run-unit-tests
       - run-unit-tests-py313
       - fossa-scan
-    if: ${{ !cancelled() && (needs.run-unit-tests-py39.result == 'success' || needs.run-unit-tests-py39.result == 'skipped') && (needs.run-unit-tests-py313.result == 'success' || needs.run-unit-tests-py313.result == 'skipped') && (needs.validate-custom-version.result == 'success' || needs.validate-custom-version.result == 'skipped') && (needs.check-docs-changes.outputs.docs-only == 'false') }}
+    if: ${{ !cancelled() && (needs.run-unit-tests.result == 'success' || needs.run-unit-tests.result == 'skipped') && (needs.run-unit-tests-py313.result == 'success' || needs.run-unit-tests-py313.result == 'skipped') && (needs.validate-custom-version.result == 'success' || needs.validate-custom-version.result == 'skipped') && (needs.check-docs-changes.outputs.docs-only == 'false') }}
     outputs:
       buildname: ${{ steps.buildupload.outputs.name }}
     permissions:
@@ -3665,7 +3665,7 @@ jobs:
       - semgrep
       - build
       - build-py313
-      - run-unit-tests-py39
+      - run-unit-tests
       - run-unit-tests-py313
       - appinspect
       - setup

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -760,7 +760,7 @@ jobs:
       block_mode: "policy"
 
   run-unit-tests-py39:
-    name: run-unit-tests (3.9)
+    name: run-unit-tests (${{ inputs.python-version }})
     runs-on: ubuntu-22.04
     needs:
       - setup-workflow
@@ -773,7 +773,7 @@ jobs:
       statuses: read
       checks: write
     env:
-      UNIT_TESTS_PYTHON_VERSION: "3.9"
+      UNIT_TESTS_PYTHON_VERSION: ${{ inputs.python-version }}
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -838,7 +838,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - setup-workflow
-    if: ${{ needs.setup-workflow.outputs.execute-unit == 'true' }}
+    if: ${{ needs.setup-workflow.outputs.execute-unit == 'true' && inputs.python-version != '3.13' }}
     permissions:
       actions: read
       deployments: read

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ gitGraph
 * `scripted-inputs-os-list` - list of OSes used for scripted inputs tests (default includes ubuntu 16.04–24.04 and redhat 8.4–9.5)
 * `upgrade-tests-ta-versions` - list of TA versions (format `X.X.X`) used as starting points for upgrade tests; e.g. `['7.6.0', '7.7.0']`
 * `wfe-run-on-splunk-latest` - when `true` forces WFE tests to run only on the latest Splunk version; when `false` runs on all supported Splunk versions required for release; default `false`
-* `python-version` - Python version used for testing, default `3.9`
+* `python-version` - Python version used to build the package and run the package-version unit-test job, default `3.9`
+* `test-python-version` - Python version used for pre-commit, WFE test tooling, and test dependencies; defaults to `python-version`
 * `spl2-generate` - when `true` enables SPL2 generation, default `false`
 * `gs-image-version` - version of the GS Scorecard Docker image, default `1.2`
 * `gs-version` - version of the GS Scorecard tool, default `0.3`
@@ -695,7 +696,7 @@ gs-scorecard-report (gs_scorecard.html)
 
 **Description:**
 
-- Unit tests run in two parallel jobs, `run-unit-tests-py39` and `run-unit-tests-py313`, executing the same suite against Python 3.9 and 3.13 respectively.
+- Unit tests run against the configured `python-version`. A separate Python 3.13 job also runs unless `python-version` is already Python 3.13, avoiding duplicate coverage and artifact names.
 
 **Action used:** NA
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ gitGraph
 * `upgrade-tests-ta-versions` - list of TA versions (format `X.X.X`) used as starting points for upgrade tests; e.g. `['7.6.0', '7.7.0']`
 * `wfe-run-on-splunk-latest` - when `true` forces WFE tests to run only on the latest Splunk version; when `false` runs on all supported Splunk versions required for release; default `false`
 * `python-version` - Python version used to build the package and run the package-version unit-test job, default `3.9`
-* `test-python-version` - Python version used for pre-commit, WFE test tooling, and test dependencies; defaults to `python-version`
+* `test-python-version` - Python version used for pre-commit, WFE test tooling, and test dependencies, default `3.13`
 * `spl2-generate` - when `true` enables SPL2 generation, default `false`
 * `gs-image-version` - version of the GS Scorecard Docker image, default `1.2`
 * `gs-version` - version of the GS Scorecard tool, default `0.3`


### PR DESCRIPTION
## Summary

Separates the Python interpreter used to build an add-on package from the interpreter used by validation and WFE test tooling.

- `python-version` controls package build and the package-version unit-test job (default: Python 3.9).
- `test-python-version` controls pre-commit, test-dependency setup, generated test libraries, and WFE test runners (default: Python 3.13).
- Retains separate Python 3.13 unit-test coverage unless `python-version` is already 3.13, preventing duplicate test artifacts.
- Allows add-ons such as O365 to build a Splunk 9.4/10.0-compatible package with Python 3.9 while running PSA, SmartX, and UCC 3.0 tooling with Python 3.13.

## Breaking change

WFE test tooling now defaults to Python 3.13 independently of the package-build interpreter. Callers that require a different test interpreter must explicitly set `test-python-version`.

## Validation

- YAML parsing passed.
- `git diff --check` passed.
- PR CI checks passed.

Related: splunk/splunk-add-on-for-microsoft-office-365#1018