### PR TITLE
fix: handle single test reports and downgrade AppInspect CLI

### DIFF
--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1262,7 +1262,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.15.0
+        uses: splunk/appinspect-cli-action@v2.1.1
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -2004,13 +2004,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-ko*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-ko*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No knowledge-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -2284,13 +2290,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-ui*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-ui-*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No UI-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -2562,13 +2574,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-modinput*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-modinput*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No modinput-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -2839,13 +2857,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-ucc_modinput*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-ucc_modinput*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No UCC modinput-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -3105,13 +3129,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-upgrade*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-upgrade*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No upgrade-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -3376,13 +3406,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-scripted*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-scripted*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No scripted-input-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
@@ -3629,13 +3665,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: summary-spl2_integration_tests*
+          path: summaries
       - name: Combine summaries into a table
         run: |
           echo "| Job | Total Tests | Passed Tests | Failed Tests | Errored Tests | Skipped Tests | Report Link" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------- | ----------- | ------ | ------ | ------ | ------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          for file in summary-spl2_integration_tests*/job_summary.txt; do
+          summary_files=$(find summaries -type f -name job_summary.txt -print | sort)
+          if [[ -z "$summary_files" ]]; then
+            echo "::error::No SPL2 integration-test summary artifacts were downloaded"
+            exit 1
+          fi
+          while IFS= read -r file; do
             cat "$file" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done <<< "$summary_files"
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: |

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -1262,7 +1262,7 @@ jobs:
           name: package-splunkbase
           path: build/package/
       - name: Scan
-        uses: splunk/appinspect-cli-action@v2.1.1
+        uses: splunk/appinspect-cli-action@v2.11
         with:
           app_path: build/package/
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
### Description

Fix aggregate test-report jobs when a test matrix produces a single summary artifact, and pin the AppInspect CLI action to v2.1.1 (ref: https://splunk.slack.com/archives/C9YHF0HEJ/p1781698303793169).

### Checklist

- [x] `README.md` has been updated or is not required
- [ ] push trigger tests
- [ ] manual release test
- [ ] automated releases test
- [ ] pull request trigger tests
- [ ] schedule trigger tests
- [x] workflow errors/warnings reviewed and addressed

### Testing done

- `git diff --check` passed.
- `actionlint` passed with the repository's unrelated pre-existing `create-github-app-token` and `vendor-version` diagnostics excluded.
- Shell-level summary discovery check passed for zero, one, and multiple artifact layouts.
- Isolated PR branch contains only `.github/workflows/reusable-build-test-release.yml` changes.
- 
https://github.com/splunk/splunk-add-on-for-symantec-endpoint-protection/actions/runs/33163176345