### PR TITLE
chore: remove pre-commit and standalone SPL2 jobs

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -24,21 +24,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  pre-commit:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.7"
-      - run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.6.26/scripts/download-actionlint.bash)
-      - uses: pre-commit/action@v3.0.1
-
   publish:
     needs:
       - compliance-copyrights
-      - pre-commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3

--- a/.github/workflows/reusable-build-test-release.yml
+++ b/.github/workflows/reusable-build-test-release.yml
@@ -62,11 +62,6 @@ on:
         description: "Python version to use for testing"
         type: string
         default: "3.9"
-      spl2-generate:
-        required: false
-        description: "Run spl2-generate hook during pre-commit step"
-        type: boolean
-        default: false
       gs-image-version:
         required: false
         description: "Version of the GS scorecard Docker image"
@@ -703,26 +698,6 @@ jobs:
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v6.0.0
 
-  pre-commit:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Run pre-commit (skip spl2-generate)
-        if: ${{ !inputs['spl2-generate'] }}
-        uses: pre-commit/action@v3.0.1
-        env:
-          SKIP: spl2-generate
-      - name: Run pre-commit (with spl2-generate)
-        if: ${{ inputs['spl2-generate'] }}
-        uses: pre-commit/action@v3.0.1
-
   review_secrets:
     name: security-detect-secrets
     runs-on: ubuntu-latest
@@ -909,7 +884,6 @@ jobs:
       - setup-workflow
       - meta
       - compliance-copyrights
-      - pre-commit
       - review_secrets
       - semgrep
       - run-unit-tests-py39
@@ -1130,7 +1104,6 @@ jobs:
       - setup-workflow
       - meta
       - compliance-copyrights
-      - pre-commit
       - review_secrets
       - semgrep
       - run-unit-tests-py313
@@ -1700,50 +1673,6 @@ jobs:
           name: archive splunk ${{ matrix.splunk.version }}${{ secrets.OTHER_TA_REQUIRED_CONFIGS }} ${{ env.TEST_TYPE }} tests logs
           path: |
             ${{ needs.setup.outputs.directory-path }}/argo-logs
-
-  run-spl2-tests:
-    if: ${{ !cancelled() && needs.setup-workflow.outputs.execute-spl2 == 'true'}}
-    needs:
-      - setup-workflow
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/splunk/spl2-testing-base:latest
-    permissions:
-      actions: read
-      deployments: read
-      contents: read
-      packages: read
-      statuses: read
-      checks: write
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-      - name: configure git # This step configures git to omit "dubious git ownership error" in later test-reporter stage
-        id: configure-git
-        run: |
-          git --version
-          git_path="$(pwd)"
-          echo "$git_path"
-          git config --global --add safe.directory "$git_path"
-      - name: Run spl2 tests
-        run: |
-          echo "Running SPL2 Tests"
-          spl2_tests_run cli -n 8 --cli_cache --ignore_additional_fields_in_actual --ignore_empty_strings -o log_cli=true --log-cli-level=INFO --verbose --junitxml test-results/report.xml
-      - name: Test Report
-        id: test_report
-        uses: dorny/test-reporter@v3.0.0
-        if: ${{ !cancelled() }}
-        with:
-          name: spl2 test report
-          path: "test-results/*.xml"
-          reporter: java-junit
-          use-actions-summary: false
-      - uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() }}
-        with:
-          name: spl2 test results
-          path: test-results/
 
   run-knowledge-tests:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.setup-workflow.outputs.execute-knowledge == 'true' }}
@@ -3696,7 +3625,6 @@ jobs:
       - validate-custom-version
       - meta
       - compliance-copyrights
-      - pre-commit
       - review_secrets
       - semgrep
       - build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@
   * [[Job] setup](#job-setup)
   * [[Job] test-unit-python3](#job-test-unit-python3)
   * [[Job] run-btool-check](#job-run-btool-check)
-  * [[Job] run-spl2-tests](#job-run-spl2-tests)
   * [[Job] run-knowledge-tests](#job-run-knowledge-tests)
   * [[Job] run-ui-tests](#job-run-ui-tests-)
   * [[Job] run-modinput-tests](#job-run-modinput-tests-)
@@ -189,7 +188,6 @@ gitGraph
 * `upgrade-tests-ta-versions` - list of TA versions (format `X.X.X`) used as starting points for upgrade tests; e.g. `['7.6.0', '7.7.0']`
 * `wfe-run-on-splunk-latest` - when `true` forces WFE tests to run only on the latest Splunk version; when `false` runs on all supported Splunk versions required for release; default `false`
 * `python-version` - Python version used for testing, default `3.9`
-* `spl2-generate` - when `true` enables SPL2 generation, default `false`
 * `gs-image-version` - version of the GS Scorecard Docker image, default `1.2`
 * `gs-version` - version of the GS Scorecard tool, default `0.3`
 
@@ -410,31 +408,6 @@ i.e <img src="images/compliance-copyrights/license.png" alt="license" style="wid
 **Artifacts:**
 
 - No additional Artifacts.
-
-
-## [Job] lint
-
-**Description:** 
-
-- Uses [pre-commit](https://pre-commit.com) to run linters (Python, Java, JS and others)
-
-**Action used** https://github.com/pre-commit/action
-
-**Pass/fail behaviour:**
-
-- If the stage detects a linting error in the code the stage would fail with error information.
-
-**Troubleshooting steps for failures if any**
-
-- User can install `pre-commit` locally and run all the linters locally (`pre-commit run --all-files`) and resolve all the issues without the necessity to test changes in the CI.
-
-- User can look through the details for failures in logs and browse how to resolve a specific linters error i.e for flake8 failures one in install flake8 in local env and fix the failures and push to the repository.
-
-- If your add-on has some Java code, you need to have Java installed locally, so Java linter will work.
-
-**Artifacts:**
-
-- No additional artifacts, failure details are available in the logs.
 
 
 ## [Job] security-detect-secrets
@@ -735,25 +708,6 @@ gs-scorecard-report (gs_scorecard.html)
 ```
 btool-output.txt
 ```
-
-## [Job] run-spl2-tests
-
-**Description:**
-
-- Executes SPL2 tests for add-ons that ship SPL2 modules under `package/default/data/spl2/`.
-- Runs inside the `ghcr.io/splunk/spl2-testing-base:latest` container using the `spl2_tests_run` CLI.
-- Triggered when `package/default/data/spl2/` directory is detected in the repository.
-
-**Pass/fail behaviour:**
-
-- Fails if any SPL2 test case fails.
-
-**Artifacts:**
-
-```
-Junit XML test report
-```
-
 
 ## [Job] run-knowledge-tests
 


### PR DESCRIPTION
### Description

Remove the standalone pre-commit and SPL2 test jobs from the reusable workflow and repository release workflow. Remove their dependency references and obsolete documentation/input configuration. Keep the separate SPL2 integration-test path.

### Testing done

- `git diff --check` passed.
- `actionlint` passed with unrelated pre-existing `create-github-app-token` and `vendor-version` diagnostics excluded.
- Confirmed no remaining `pre-commit`, `run-spl2-tests`, or `spl2-generate` references in workflow/README files.
- Confirmed `run-spl2-integration-tests` and its report job remain present.